### PR TITLE
libs: ignore freeRTOS platform

### DIFF
--- a/libs/.mbedignore
+++ b/libs/.mbedignore
@@ -73,6 +73,7 @@ no-OS/drivers/platform/generic/
 no-OS/drivers/platform/linux/
 no-OS/drivers/platform/maxim/
 no-OS/drivers/platform/stm32/
+no-OS/drivers/platform/freeRTOS/
 no-OS/drivers/platform/xilinx/
 no-OS/drivers/platform/pico/
 no-OS/drivers/platform/chibios/


### PR DESCRIPTION
After:
`b5692509d tools/scripts: added general makefile`

We get a build error:

```
Compile [  9.3%]: freertos_delay.c
[Fatal Error] freertos_delay.c@40,10: FreeRTOS.h: No such file or directory [ERROR] ./libs/no-OS/drivers/platform/freeRTOS/freertos_delay.c:40:10: fatal error: FreeRTOS.h: No such file or directory
   40 | #include "FreeRTOS.h"
```

Avoid building freeRTOS platform by adding it to the `.mbedigore`