### PR TITLE
.github: workflow: Fixup gh-pages commit

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -77,13 +77,10 @@ jobs:
 
     - name: Commit gh-pages
       run: |
-        author=$(git log -1 --pretty=format:'%an')
-        email=$(git log -1 --pretty=format:'%ae')
-        commit=$(git rev-parse --short HEAD)
         git add . >> /dev/null
-        git config --global user.name "$author"
-        git config --global user.email "$email"
-        git commit -m "deploy: $commit" --allow-empty
+        git config --global user.name "${{ github.event.head_commit.committer.name }}"
+        git config --global user.email "${{ github.event.head_commit.committer.email }}"
+        git commit -m "deploy: ${GITHUB_SHA}" --allow-empty
         
     - name: Push to gh-pages
       run: >-


### PR DESCRIPTION
Currently, the gh-pages commit is taking the author, sha and email from the head commit from the gh-pages.
Fixup this to take from the head commit from the main branch (considering the workflow only runs on push to main).
Please note that GITHUB_SHA takes different values depending on the run context:
* push: current branch head commit sha
* pull_request: temporary merge commit sha
But since the workflow only runs on push to main, that is not an issue.