### PR TITLE
projects:ad719x_iio:Add Support for AD7194

### DIFF
--- a/doc/sphinx/source/projects/ad719x_iio/ad719x_iio.rst
+++ b/doc/sphinx/source/projects/ad719x_iio/ad719x_iio.rst
@@ -15,7 +15,10 @@ Supported Hardware
 
 **Supported Evaluation Boards:**
 
-* TODO: Update when Eval boards links are available.
+* `EVAL-AD7190 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7190asdz.html>`_
+* `EVAL-AD7192 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7192asdz.html>`_
+* `EVAL-AD7193 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7193asdz.html>`_
+* `EVAL-AD7195 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7195asdz.html>`_
 
 **Supported Carrier Boards:**
 

--- a/projects/ad719x_iio/README.txt
+++ b/projects/ad719x_iio/README.txt
@@ -1,6 +1,6 @@
 Evaluation Boards/Products Supported
 ------------------------------------ 
--Products supported: AD7190, AD7192, AD7193, AD7195
+-Products supported: AD7190, AD7192, AD7193, AD7194, AD7195
 
 Overview
 --------

--- a/projects/ad719x_iio/app/ad719x_iio.h
+++ b/projects/ad719x_iio/app/ad719x_iio.h
@@ -2,7 +2,7 @@
 * @file   ad719x_iio.h
 * @brief  Header file for ad719x IIO interface
 ********************************************************************************
-* Copyright (c) 2021-22 Analog Devices, Inc.
+* Copyright (c) 2021-22,2024 Analog Devices, Inc.
 * All rights reserved.
 *
 * This software is proprietary to Analog Devices, Inc. and its licensors.
@@ -31,9 +31,9 @@
 #define CNV_START_CMD           0x5C
 #define CNV_STOP_CMD            0x58
 #define BYTES_TRANSFER_THREE    3
-/* For AD7190/2/5 the channel mask needs to shifted by 4,
+/* For AD7190/2/4/5 the channel mask needs to shifted by 4,
  * when operating in pseudo differential mode.*/
-#define AD7190_2_5_CHN_SHIFT    4
+#define AD719X_CHN_SHIFT    4
 
 /******************************************************************************/
 /********************** Public/Extern Declarations ****************************/

--- a/projects/ad719x_iio/app/ad719x_user_config.c
+++ b/projects/ad719x_iio/app/ad719x_user_config.c
@@ -2,7 +2,7 @@
  *   @file   ad719x_user_config.c
  *   @brief  User configuration file for AD719X device
 ******************************************************************************
-* Copyright (c) 2021-22 Analog Devices, Inc.
+* Copyright (c) 2021-22,2024 Analog Devices, Inc.
 *
 * All rights reserved.
 *
@@ -69,6 +69,8 @@ struct ad719x_init_param ad719x_init_params = {
 	.chip_id = AD7192
 #elif defined(DEV_AD7193)
 	.chip_id = AD7193
+#elif defined(DEV_AD7194)
+	.chip_id = AD7194
 #elif defined(DEV_AD7195)
 	.chip_id = AD7195
 #endif

--- a/projects/ad719x_iio/app/app_config.c
+++ b/projects/ad719x_iio/app/app_config.c
@@ -4,7 +4,7 @@
  *   @details This module contains the configurations needed for ad719x
  *            IIO application firmware
 ********************************************************************************
- * Copyright (c) 2021-23 Analog Devices, Inc.
+ * Copyright (c) 2021-24 Analog Devices, Inc.
  * All rights reserved.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
@@ -30,7 +30,7 @@
 /******************************************************************************/
 /* UART init parameters structure */
 struct no_os_uart_init_param uart_init_params = {
-	.device_id = NULL,
+	.device_id = 0,
 	.baud_rate = IIO_UART_BAUD_RATE,
 	.size = NO_OS_UART_CS_8,
 	.parity = NO_OS_UART_PAR_NO,

--- a/projects/ad719x_iio/app/app_config.h
+++ b/projects/ad719x_iio/app/app_config.h
@@ -2,7 +2,7 @@
  *   @file   app_config.h
  *   @brief  Configuration file for ad719x IIO firmware application
 ******************************************************************************
-* Copyright (c) 2021-23 Analog Devices, Inc.
+* Copyright (c) 2021-24 Analog Devices, Inc.
 *
 * All rights reserved.
 *
@@ -100,34 +100,35 @@
 #if defined(DEV_AD7190)
 #define ACTIVE_DEVICE_NAME	"ad7190"
 #define DEVICE_NAME			"DEV_AD7190"
-#define ACTIVE_DEVICE_ID	 ID_AD7190
 #define HW_MEZZANINE_NAME	"EVAL-AD7190-ASDZ"
 #elif defined(DEV_AD7192)
 #define ACTIVE_DEVICE_NAME	"ad7192"
 #define DEVICE_NAME			"DEV_AD7192"
-#define ACTIVE_DEVICE_ID	 ID_AD7192
 #define HW_MEZZANINE_NAME	"EVAL-AD7192-ASDZ"
 #elif defined(DEV_AD7193)
 #define ACTIVE_DEVICE_NAME	"ad7193"
 #define DEVICE_NAME			"DEV_AD7193"
-#define ACTIVE_DEVICE_ID	 ID_AD7193
 #define HW_MEZZANINE_NAME	"EVAL-AD7193-ASDZ"
+#elif defined(DEV_AD7194)
+#define ACTIVE_DEVICE_NAME	"ad7194"
+#define DEVICE_NAME			"DEV_AD7194"
+#define HW_MEZZANINE_NAME	"EVAL-AD7194ASDZ"
 #elif defined(DEV_AD7195)
 #define ACTIVE_DEVICE_NAME	"ad7195"
 #define DEVICE_NAME			"DEV_AD7195"
-#define ACTIVE_DEVICE_ID	 ID_AD7195
 #define HW_MEZZANINE_NAME	"EVAL-AD7195-ASDZ"
 #else
 #warning No/Unsupported ADxxxxy symbol defined. AD7193 defined
 #define DEV_AD7193
 #define ACTIVE_DEVICE_NAME	"ad7193"
 #define DEVICE_NAME			"DEV_AD7193"
-#define ACTIVE_DEVICE_ID	 ID_AD7193
 #define HW_MEZZANINE_NAME	"EVAL-AD7193-ASDZ"
 #endif // Device Select (Active Device name definition)
 
 #if defined(DEV_AD7190) || defined(DEV_AD7192) || defined(DEV_AD7195)
 #define	NO_OF_CHANNELS		4
+#elif defined(DEV_AD7194)
+#define NO_OF_CHANNELS		16
 #else
 #define NO_OF_CHANNELS		8
 #endif

--- a/projects/ad719x_iio/ci_build.groovy
+++ b/projects/ad719x_iio/ci_build.groovy
@@ -4,7 +4,7 @@ def getBuildMatrix(projectName) {
 		// This map is for building all targets when merging to main or develop branches
 		buildMap = [
 			PLATFORM_NAME: ['SDP_K1', 'NUCLEO_L552ZE_Q', 'DISCO_F769NI'],
-			ACTIVE_DEVICE: ['DEV_AD7190', 'DEV_AD7192', 'DEV_AD7193', 'DEV_AD7195'],
+			ACTIVE_DEVICE: ['DEV_AD7190', 'DEV_AD7192', 'DEV_AD7193', 'DEV_AD7194', 'DEV_AD7195'],
 			COM_TYPE: ['USE_PHY_COM_PORT','USE_VIRTUAL_COM_PORT'],
 			SDRAM: ['USE_SDRAM', 'NO_SDRAM']
 		]
@@ -30,24 +30,29 @@ def getBuildMatrix(projectName) {
 		// Skip 'all platforms except SDP-K1 + all devices except AD7193'
 		!(axis['PLATFORM_NAME'] == 'NUCLEO_L552ZE_Q' && axis['ACTIVE_DEVICE'] == 'DEV_AD7190') &&
 		!(axis['PLATFORM_NAME'] == 'NUCLEO_L552ZE_Q' && axis['ACTIVE_DEVICE'] == 'DEV_AD7192') &&
+		!(axis['PLATFORM_NAME'] == 'NUCLEO_L552ZE_Q' && axis['ACTIVE_DEVICE'] == 'DEV_AD7194') &&
 		!(axis['PLATFORM_NAME'] == 'NUCLEO_L552ZE_Q' && axis['ACTIVE_DEVICE'] == 'DEV_AD7195') &&
 		!(axis['PLATFORM_NAME'] == 'DISCO_F769NI' && axis['ACTIVE_DEVICE'] == 'DEV_AD7190') &&
 		!(axis['PLATFORM_NAME'] == 'DISCO_F769NI' && axis['ACTIVE_DEVICE'] == 'DEV_AD7192') &&
+		!(axis['PLATFORM_NAME'] == 'DISCO_F769NI' && axis['ACTIVE_DEVICE'] == 'DEV_AD7194') &&
 		!(axis['PLATFORM_NAME'] == 'DISCO_F769NI' && axis['ACTIVE_DEVICE'] == 'DEV_AD7195') &&
 
 		// Skip 'SDP-K1 + SDRAM + Phy COM + all devices except DEV_AD7193'
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7190' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7192' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
+		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7194' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7195' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
 
 		// Skip 'SDP-K1 + No SDRAM + Phy COM + all devices except DEV_AD7193'
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7190' && axis['SDRAM'] == 'NO_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7192' && axis['SDRAM'] == 'NO_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
+		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7194' && axis['SDRAM'] == 'NO_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7195' && axis['SDRAM'] == 'NO_SDRAM' && axis['COM_TYPE'] == 'USE_PHY_COM_PORT') &&
 
 		// Skip 'SDP-K1 + SDRAM + VCOM + all devices except DEV_AD7193'
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7190' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_VIRTUAL_COM_PORT') &&
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7192' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_VIRTUAL_COM_PORT') &&
+		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7194' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_VIRTUAL_COM_PORT') &&
 		!(axis['PLATFORM_NAME'] == 'SDP_K1' && axis['ACTIVE_DEVICE'] == 'DEV_AD7195' && axis['SDRAM'] == 'USE_SDRAM' && axis['COM_TYPE'] == 'USE_VIRTUAL_COM_PORT')
 	}
 


### PR DESCRIPTION
Add support for ad7194 in ad719x family.
Updated product and eval board links in the documentation. Updated Readme.txt.