### PR TITLE
doc:sphinx:ad405x_iio: Mention STM32 platform

### DIFF
--- a/doc/sphinx/source/projects/ad405x_iio/ad405x_iio.rst
+++ b/doc/sphinx/source/projects/ad405x_iio/ad405x_iio.rst
@@ -15,7 +15,7 @@ Supported Hardware
 
 **Supported Carrier Boards:**
 
-* `SDP-K1 With Mbed Platform <https://os.mbed.com/platforms/SDP_K1/>`_
+* SDP-K1 With `Mbed <https://os.mbed.com/platforms/SDP_K1/>`_ and STM32 platforms.
 
 ============
 Introduction


### PR DESCRIPTION
1. Mention STM32 platform in the 'supported carriers' section