### PR TITLE
projects:ad405x_iio:Add support for large capture

### DIFF
--- a/doc/sphinx/source/iio_osc/data_streaming.rst
+++ b/doc/sphinx/source/iio_osc/data_streaming.rst
@@ -122,5 +122,5 @@ data streaming request.
 
 Buffer size can be increased to larger value by making use of internal/external RAMs. 
 For example, SDP-K1 MCU board has 16Mbytes of onboard SDRAM, which allows larger data 
-buffer size in the firmware. By enabling SDRAM in the SDP-K1 targeted Mbed firmware 
-(app_config.h file), the data buffer size can be increased to 16Mbytes.
+buffer size in the firmware. By enabling SDRAM in the SDP-K1 
+(using the macro in app_config.h file), the data buffer size can be increased to 16Mbytes.

--- a/projects/ad405x_iio/app/ad405x_iio.h
+++ b/projects/ad405x_iio/app/ad405x_iio.h
@@ -2,7 +2,7 @@
  *   @file   ad405x_iio.h
  *   @brief  Header for AD405X IIO application
 ******************************************************************************
-* Copyright (c) 2023-24 Analog Devices, Inc.
+* Copyright (c) 2023-2024 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad405x_iio/app/ad405x_user_config.h
+++ b/projects/ad405x_iio/app/ad405x_user_config.h
@@ -2,7 +2,7 @@
  *   @file   ad405x_user_config.h
  *   @brief  Header for AD405X user configuration file
 ******************************************************************************
-* Copyright (c) 2023-24 Analog Devices, Inc.
+* Copyright (c) 2023-2024 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad405x_iio/app/app_config.h
+++ b/projects/ad405x_iio/app/app_config.h
@@ -204,10 +204,7 @@
 #endif
 
 /* Enable/Disable the use of SDRAM for ADC data capture buffer */
-#define USE_SDRAM	// Uncomment to use SDRAM as data buffer
-
-/* Maximum value the DMA NDTR register can take */
-#define MAX_DMA_NDTR		65535
+//#define USE_SDRAM	// Uncomment to use SDRAM as data buffer
 
 /******************************************************************************/
 /********************** Variables and User Defined Data Types *****************/

--- a/projects/ad405x_iio/app/app_config_stm32.h
+++ b/projects/ad405x_iio/app/app_config_stm32.h
@@ -2,7 +2,7 @@
  *   @file    app_config_stm32.h
  *   @brief   Header file for STM32 platform configurations
 ********************************************************************************
- * Copyright (c) 2023-24 Analog Devices, Inc.
+ * Copyright (c) 2023-2024 Analog Devices, Inc.
  * All rights reserved.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
@@ -164,12 +164,12 @@ extern volatile bool ad405x_conversion_flag;
 extern struct stm32_dma_init_param stm32_spi_dma_extra_init_params;
 extern struct stm32_dma_channel rxdma_channel;
 extern struct stm32_dma_channel txdma_channel;
+extern uint32_t rxdma_ndtr;
 #endif
 
 extern int dma_cycle_count;
-extern bool more_than_64k_requested;
-
-void rxM1cmplt_callback(DMA_HandleTypeDef * hdma);
+void halfcmplt_callback(DMA_HandleTypeDef * hdma);
+void update_buff(uint32_t* local_buf, uint32_t* buf_start_addr);
 void stm32_system_init(void);
 void stm32_timer_enable(void);
 void stm32_timer_stop(void);


### PR DESCRIPTION
1. Remove DMA double buffering
2. Use ping pong implementation where DMA always writes to SRAM buffer
3. Increase the size of SRAM IIO buffer to 128KB