### PR TITLE
Dummy

### DIFF
--- a/doc/sphinx/source/build/project_build.rst
+++ b/doc/sphinx/source/build/project_build.rst
@@ -56,12 +56,6 @@ for respective platform.
 
             * Install `STM32CubeMX <https://www.st.com/en/development-tools/stm32cubemx.html>`_
 
-            * Install `Git <https://git-scm.com/downloads>`_ and add a path of **C:\\Program Files\\Git\\usr\\bin\\** directory into system environmental path variable (please verify your git installation path is correct).
-
-            * Install `Make <https://gnuwin32.sourceforge.net/packages/make.htm>`_ in the root of 'C' drive without any spaces in the installation path. The path must be **C:\\GnuWin32\\…**. Add this path into the system environmental path variable (as shown in below screenshot).
-
-            * Install `GNU Arm Embedded compiler <https://developer.arm.com/downloads/-/gnu-rm.>`_ (for the development, 9-2019-q4-major version is used) and add a path of GNU Arm Embedded Toolchain bin directory into the system environmental path variable (as shown in below screenshot).
-
                .. image:: /source/build/environmental_variables.png
                   :width: 400
 
@@ -143,7 +137,7 @@ and generate executable file (.bin/.hex)
                .. image:: /source/build/stm32_exclude_files_option.png
                   :width: 600
 
-            * In order to choose STM32 platform in the firmware, select the "ACTIVE_PLATFORM" as "STM32_PLATFORM" in the app_config.h from the respective project.
+            * In order to choose STM32 platform in the firmware, select the "ACTIVE_PLATFORM" as "STM32_PLATFORM" in the app_config.h from the respective project. Alternately , add compiler flag "ACTIVE_PLATFORM=value of STM32_PLATFORM in app_config.h" for selecting stm32 platform.
 
             * Add compiler flags "-u _printf_float" to the project settings.
 


### PR DESCRIPTION
Add ACTIVE_PLATFORM=STM32_PLATFORM flag  for selecting stm32 Remove make, git and GNU toolchain as it is not needed for stm based build