### PR TITLE
projects:ad7124_iio:Fixing STM Build error

### DIFF
--- a/projects/ad7124_iio/app/app_config_stm32.c
+++ b/projects/ad7124_iio/app/app_config_stm32.c
@@ -42,7 +42,7 @@ struct stm32_uart_init_param stm32_uart_extra_init_params = {
 
 /* SPI STM32 Platform Specific Init Parameters */
 struct stm32_spi_init_param stm32_spi_extra_init_params = {
-	.chip_select_port = STM32_SPI_CS_PORT,
+	.chip_select_port = SPI_CS_PORT,
 	.get_input_clock = HAL_RCC_GetSysClockFreq_app
 };
 

--- a/projects/ad7124_iio/app/app_config_stm32.h
+++ b/projects/ad7124_iio/app/app_config_stm32.h
@@ -19,6 +19,7 @@
 
 #include "stm32_uart.h"
 #include "stm32_spi.h"
+#include "stm32_i2c.h"
 #include "stm32_gpio.h"
 #include "stm32_irq.h"
 #include "stm32_gpio_irq.h"


### PR DESCRIPTION
Added stm32_i2c.h in app_config_stm32.h includes.
Corrected chip select Macro in app_config_stm32.c