### PR TITLE
projects:ad4170_iio: Fix build errors

### DIFF
--- a/libraries/.mbedignore
+++ b/libraries/.mbedignore
@@ -18,6 +18,8 @@ no-OS/drivers/adc/ad6676/
 no-OS/drivers/adc/ad7091r/
 no-OS/drivers/adc/ad7091r5/
 no-OS/drivers/adc/ad7280a/
+no-OS/drivers/adc/ad738x/
+no-OS/drivers/adc/ad7606/
 no-OS/drivers/adc/ad9081/
 no-OS/drivers/adc/ad9208/
 no-OS/drivers/adc/ad9250/
@@ -42,6 +44,7 @@ no-OS/drivers/dac/dac_demo/
 no-OS/drivers/dac/ad7293/
 no-OS/drivers/dac/ad9144/
 no-OS/drivers/dac/max538x/
+no-OS/drivers/dac/ad3552r/
 no-OS/drivers/dac/ad5449/
 no-OS/drivers/dac/ad5421/
 no-OS/drivers/dac/ad5446/
@@ -77,12 +80,15 @@ no-OS/drivers/platform/pico/
 no-OS/drivers/platform/chibios/
 no-OS/drivers/platform/freeRTOS/
 no-OS/drivers/potentiometer/
+no-OS/drivers/power/
 no-OS/drivers/rf-transceiver/
 no-OS/drivers/sd-card/
 no-OS/drivers/temperature/max31855/
 no-OS/drivers/temperature/max31875/
 no-OS/drivers/temperature/max31865pmb1/
+no-OS/drivers/temperature/max31827/
 no-OS/drivers/temperature/adt75/
+no-OS/drivers/temperature/ltc2983/
 no-OS/drivers/display/
 no-OS/drivers/filter/
 no-OS/drivers/switch/
@@ -100,7 +106,7 @@ no-OS/projects/
 no-OS/scripts/
 no-OS/tools/
 no-OS/v4l2_config/
-no-OS/jesd204/
+no-OS/drivers/api/no_os_i3c.c
 
 # Ignoring files for pocket lab applications
 lvgl/examples/

--- a/projects/ad4170_iio/app/ad4170_iio.c
+++ b/projects/ad4170_iio/app/ad4170_iio.c
@@ -573,9 +573,6 @@ static int get_adc_raw(void *device,
 		if (ret) {
 			break;
 		}
-		if (channel->scan_type.sign == 's')
-			adc_data_raw = no_os_sign_extend32(adc_data_raw,
-							   channel->scan_type.realbits - 1);
 
 		perform_sensor_measurement_and_update_scale(adc_data_raw, channel->ch_num);
 		return sprintf(buf, "%d", adc_data_raw);
@@ -2323,7 +2320,7 @@ static int32_t iio_ad4170_prepare_transfer(void *dev_instance,
 		return ret;
 	}
 
-	spi_init_param = ad4170_user_config_params.spi_init.extra;
+	spi_init_param = ad4170_init_params.spi_init.extra;
 	spi_init_param->dma_init = &ad4170_dma_init_param;
 
 	spi_init_param->irq_num = Rx_DMA_IRQ_ID;
@@ -2332,7 +2329,7 @@ static int32_t iio_ad4170_prepare_transfer(void *dev_instance,
 
 	/* Init SPI interface in DMA Mode */
 	ret = no_os_spi_init(&p_ad4170_dev_inst->spi_desc,
-			     &ad4170_user_config_params.spi_init);
+			     &ad4170_init_params.spi_init);
 	if (ret) {
 		return ret;
 	}
@@ -2380,12 +2377,12 @@ static int32_t iio_ad4170_end_transfer(void *dev)
 
 	stm32_abort_dma_transfer();
 
-	spi_init_param = ad4170_user_config_params.spi_init.extra;
+	spi_init_param = ad4170_init_params.spi_init.extra;
 	spi_init_param->dma_init = NULL;
 
 	/* Init SPI Interface in normal mode (Non DMA) */
 	ret = no_os_spi_init(&p_ad4170_dev_inst->spi_desc,
-			     &ad4170_user_config_params.spi_init);
+			     &ad4170_init_params.spi_init);
 	if (ret) {
 		return ret;
 	}

--- a/projects/ad4170_iio/app/app_config.h
+++ b/projects/ad4170_iio/app/app_config.h
@@ -128,8 +128,8 @@
 /* Redefine the init params structure mapping w.r.t. platform */
 #define ticker_int_extra_init_params mbed_ticker_int_extra_init_params
 #if defined(USE_VIRTUAL_COM_PORT)
-#define uart_extra_init_params mbed_vcom_extra_init_params
-#define uart_ops mbed_virtual_com_ops
+#define vcom_extra_init_params mbed_vcom_extra_init_params
+#define vcom_ops mbed_virtual_com_ops
 #else
 #define uart_extra_init_params mbed_uart_extra_init_params
 #define uart_ops mbed_uart_ops


### PR DESCRIPTION
Remove the adc raw recalculation based on sign, as the offset calculation is being handled separately in the FW

Corrected the macro names being used for virtual com port in mbed platform

Updated the libraries/.mbedignore to temporarily exclude the drivers returning an error while building mbed files