### PR TITLE
doc:ad719x_iio:Updated documentation

### DIFF
--- a/doc/sphinx/source/projects/ad719x_iio/ad719x_iio.rst
+++ b/doc/sphinx/source/projects/ad719x_iio/ad719x_iio.rst
@@ -18,6 +18,7 @@ Supported Hardware
 * `EVAL-AD7190 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7190asdz.html>`_
 * `EVAL-AD7192 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7192asdz.html>`_
 * `EVAL-AD7193 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7193asdz.html>`_
+* `EVAL-AD7194 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7194asdz.html>`_
 * `EVAL-AD7195 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7195asdz.html>`_
 
 **Supported Carrier Boards:**


### PR DESCRIPTION
Updated documentation with eval board link for AD7194