### PR TITLE
libraris: no-OS: Update no-OS submodule

### DIFF
--- a/libraries/no-OS.lib
+++ b/libraries/no-OS.lib
@@ -1,1 +1,1 @@
-https://github.com/analogdevicesinc/no-OS/#0893c62f76c56e7959f68ca372ff4548f5070fb9
+https://github.com/analogdevicesinc/no-OS/#dd9a30718c4a47dbacc6df819177d3d98992204c

--- a/projects/ad355xr_iio/app/app_config_stm32.c
+++ b/projects/ad355xr_iio/app/app_config_stm32.c
@@ -70,6 +70,7 @@ struct stm32_gpio_init_param stm32_gpio_reset_init_params = {
 
 /* STM32 LDAC PWM specific parameters */
 struct stm32_pwm_init_param stm32_ldac_pwm_init_params = {
+	.htimer = &LDAC_PWM_HANDLE,
 	.prescaler = LDAC_PWM_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,
@@ -80,6 +81,7 @@ struct stm32_pwm_init_param stm32_ldac_pwm_init_params = {
 
 /* STM32 PWM specific parameters used to stop spi dma transfer */
 struct stm32_pwm_init_param stm32_spi_dma_tx_stop_pwm_init_params = {
+	.htimer = &SPI_DMA_TX_STOP_PWM_HANDLE,
 	.prescaler = SPI_DMA_TX_STOP_PWM_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,

--- a/projects/ad355xr_iio/app/app_config_stm32.h
+++ b/projects/ad355xr_iio/app/app_config_stm32.h
@@ -63,12 +63,14 @@
 #define LDAC_PWM_ID          12 //Timer12
 #define LDAC_PWM_CHANNEL     2 // Channel 2
 #define LDAC_PWM_CLK_DIVIDER 2 // multiplier to get timer clock from PLCK1
+#define LDAC_PWM_HANDLE      htim12
 
 /* STM32 PWM specific parameters to stop spi dma transfer */
 #define SPI_DMA_TX_STOP_PWM_ID   4 //Timer4
 #define SPI_DMA_TX_STOP_PWM_PRESCALER   0
 #define SPI_DMA_TX_STOP_PWM_CHANNEL     1 // Channel 1
 #define SPI_DMA_TX_STOP_PWM_CLK_DIVIDER 2 // multiplier to get timer clock from PLCK1
+#define SPI_DMA_TX_STOP_PWM_HANDLE 		htim4
 
 /* Redefine the init params structure mapping wrt platform */
 #define spi_extra_init_params   stm32_spi_init_params
@@ -121,6 +123,7 @@ extern struct stm32_pwm_init_param stm32_spi_dma_tx_stop_pwm_init_params;
 extern UART_HandleTypeDef huart5;
 extern SPI_HandleTypeDef hspi1;
 extern TIM_HandleTypeDef htim4;
+extern TIM_HandleTypeDef htim12;
 uint32_t spi_dma_tx_stop_pwm_frquency[NUMBER_OF_CHANNELS];
 
 int32_t stm32_spi_dma_enable(struct stm32_spi_desc* spidesc,

--- a/projects/ad4170_iio/app/app_config_stm32.c
+++ b/projects/ad4170_iio/app/app_config_stm32.c
@@ -130,6 +130,7 @@ struct stm32_dma_channel rxdma_channel = {
 
 /* STM32 PWM specific init params */
 struct stm32_pwm_init_param stm32_tx_trigger_extra_init_params = {
+	.htimer = &TX_TRIGGER_TIMER_HANDLE,
 	.prescaler = TIMER_8_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,

--- a/projects/ad4170_iio/app/app_config_stm32.h
+++ b/projects/ad4170_iio/app/app_config_stm32.h
@@ -2,7 +2,7 @@
  *   @file    app_config_stm32.h
  *   @brief   Header file for STM32 platform configurations
 ********************************************************************************
- * Copyright (c) 2023-2025 Analog Devices, Inc.
+ * Copyright (c) 2023-24 Analog Devices, Inc.
  * All rights reserved.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
@@ -31,7 +31,6 @@
 #if (INTERFACE_MODE == SPI_DMA_MODE)
 #include "stm32_pwm.h"
 #endif
-
 #if defined (TARGET_SDP_K1)
 #include "stm32_usb_uart.h"
 #endif
@@ -80,6 +79,7 @@
 
 /* Tx Trigger timer parameters */
 #define TX_TRIGGER_TIMER_ID         8 // Timer 8
+#define TX_TRIGGER_TIMER_HANDLE     htim8
 /* Tx trigger period considering a MAX SPI clock of 22.5MHz and 32 bit transfer */
 #define TX_TRIGGER_PERIOD           2250
 #define TX_TRIGGER_DUTY_RATIO       240
@@ -132,6 +132,25 @@
 #define STM32_SAI_BASE	SAI1_Block_A
 #endif
 
+/* Note: The below macro and the type of digital filter chosen together
+ * decides the output data rate to be configured for the device.
+ * Filter configuration can be modified by changing the macro "AD4170_FILTER_CONFIG"
+ * in the respective user configuration header file.
+ * Please refer to the datasheet for more details on the other filter configurations.
+ * It has to be noted that this is not the maximum ODR permissible by the device, but
+ * a value specific to the NUCLEO-H563ZI platform tested with a 10MHz SPI clock. The maximum
+ * ODR might vary across platforms and data continuity is not guaranteed above this ODR
+ * on the IIO Client*/
+
+/* Value corresponding to 24KSPS ODR (per channel) with Sinc5 average filter */
+#define FS_SINC5_AVG_24_KSPS	20
+
+/* Value corresponding to 512ksps ODR (per channel) with Sinc5 filter */
+#define FS_SINC5_512_KSPS		1
+
+/* Value corresponding to 62.5 ODR (per channel) with Sinc3 filter */
+#define FS_SINC3_62P5_KSPS		4
+
 #if (INTERFACE_MODE == SPI_INTERRUPT_MODE)
 #define FS_CONFIG_VALUE 	FS_SINC5_AVG_24_KSPS
 #define AD4170_MAX_SAMPLING_RATE    24000
@@ -167,6 +186,7 @@ extern struct stm32_i2c_init_param stm32_i2c_extra_init_params;
 #if !defined (TARGET_SDP_K1)
 extern UART_HandleTypeDef huart3;
 #else
+extern TIM_HandleTypeDef htim8;
 extern UART_HandleTypeDef huart5;
 extern DMA_HandleTypeDef hdma_spi1_rx;
 extern DMA_HandleTypeDef hdma_tim8_ch1;

--- a/projects/ad469x_iio/app/app_config_stm32.c
+++ b/projects/ad469x_iio/app/app_config_stm32.c
@@ -98,6 +98,7 @@ struct stm32_gpio_init_param stm32_pwm_gpio_extra_init_params = {
 
 /* STM32 PWM for specific parameters */
 struct stm32_pwm_init_param stm32_pwm_cnv_extra_init_params = {
+	.htimer = &TIMER1_HANDLE,
 	.prescaler = TIMER_1_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,
@@ -105,13 +106,19 @@ struct stm32_pwm_init_param stm32_pwm_cnv_extra_init_params = {
 	.complementary_channel = false,
 	.get_timer_clock = HAL_RCC_GetPCLK2Freq,
 	.clock_divider = TIMER_1_CLK_DIVIDER,
-	.trigger_enable = false,
+	.slave_mode = STM32_PWM_SM_DISABLE,
 	.trigger_output = PWM_TRGO_OC1
+};
+
+/* STM32 VCOM init parameters */
+struct stm32_usb_uart_init_param stm32_vcom_extra_init_params = {
+	.husbdevice = &hUsbDeviceHS,
 };
 
 #if (INTERFACE_MODE == SPI_DMA)
 /* STM32 PWM specific parameters */
 struct stm32_pwm_init_param stm32_cs_extra_init_params = {
+	.htimer = &TIMER2_HANDLE,
 	.prescaler = TIMER_2_PRESCALER,
 	.timer_autoreload = false,
 	.mode = TIM_OC_PWM1,
@@ -123,6 +130,7 @@ struct stm32_pwm_init_param stm32_cs_extra_init_params = {
 
 /* STM32 PWM specific init params */
 struct stm32_pwm_init_param stm32_tx_trigger_extra_init_params = {
+	.htimer = &TIMER8_HANDLE,
 	.prescaler = TIMER_8_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_TOGGLE,
@@ -130,7 +138,7 @@ struct stm32_pwm_init_param stm32_tx_trigger_extra_init_params = {
 	.complementary_channel = false,
 	.get_timer_clock = HAL_RCC_GetPCLK1Freq,
 	.clock_divider = TIMER_8_CLK_DIVIDER,
-	.trigger_enable = true,
+	.slave_mode = STM32_PWM_SM_TRIGGER,
 	.trigger_source = PWM_TS_ITR0,
 	.repetitions = 1,
 	.onepulse_enable = true,
@@ -194,11 +202,6 @@ uint8_t* iio_buf_current_idx;
 uint8_t* dma_buf_current_idx;
 
 #endif
-
-/* STM32 VCOM init parameters */
-struct stm32_usb_uart_init_param stm32_vcom_extra_init_params = {
-	.husbdevice = &hUsbDeviceHS,
-};
 
 /******************************************************************************/
 /************************** Functions Declaration *****************************/

--- a/projects/ad469x_iio/app/app_config_stm32.h
+++ b/projects/ad469x_iio/app/app_config_stm32.h
@@ -89,6 +89,10 @@
 #define TIMER2_ID                          2
 #define TIMER8_ID                          8
 
+#define TIMER1_HANDLE                      htim1
+#define TIMER2_HANDLE                      htim2
+#define TIMER8_HANDLE                      htim8
+
 #define Rx_DMA_IRQ_ID               DMA2_Stream0_IRQn
 #define AD469x_TxDMA_CHANNEL_NUM    DMA_CHANNEL_7
 #define AD469x_RxDMA_CHANNEL_NUM    DMA_CHANNEL_3
@@ -125,6 +129,7 @@ extern SPI_HandleTypeDef hspi1;
 extern DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim2;
+extern TIM_HandleTypeDef htim8;
 extern DMA_HandleTypeDef hdma_tim1_ch3;
 extern DMA_HandleTypeDef hdma_tim1_ch2;
 extern TIM_HandleTypeDef htim12;

--- a/projects/ad5754r_iio/app/app_config_stm32.c
+++ b/projects/ad5754r_iio/app/app_config_stm32.c
@@ -74,6 +74,7 @@ struct stm32_gpio_init_param stm32_pwm_gpio_init_params = {
 
 /* STM32 PWM for specific parameters */
 struct stm32_pwm_init_param stm32_pwm_extra_init_params = {
+	.htimer = &LDAC_PWM_HANDLE,
 	.prescaler = LDAC_PWM_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,

--- a/projects/ad5754r_iio/app/app_config_stm32.h
+++ b/projects/ad5754r_iio/app/app_config_stm32.h
@@ -62,6 +62,7 @@
 #define LDAC_PWM_CHANNEL     3 // Channel3
 #define LDAC_PWM_CLK_DIVIDER 2 // multiplier to get timer clock from PLCK1
 #define LDAC_PWM_PRESCALER   3
+#define LDAC_PWM_HANDLE      htim1
 
 /* Priority of the LDAC Interrupt */
 #define LDAC_GPIO_PRIORITY 1

--- a/projects/ad579x_iio/app/app_config_stm32.c
+++ b/projects/ad579x_iio/app/app_config_stm32.c
@@ -78,6 +78,7 @@ struct stm32_gpio_init_param stm32_gpio_reset_init_params = {
 
 /* STM32 LDAC PWM specific parameters */
 struct stm32_pwm_init_param stm32_pwm_extra_init_params = {
+	.htimer = &LDAC_PWM_HANDLE,
 	.prescaler = LDAC_PWM_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,

--- a/projects/ad579x_iio/app/app_config_stm32.h
+++ b/projects/ad579x_iio/app/app_config_stm32.h
@@ -76,10 +76,11 @@
 #define MAX_SAMPLING_RATE					(71428)
 
 /* STM32 LDAC PWM Specific parameters */
-#define LDAC_PWM_ID          4 //Timer12
+#define LDAC_PWM_ID          4 //Timer4
 #define LDAC_PWM_CHANNEL     1 // Channel 2
 #define LDAC_PWM_CLK_DIVIDER 2 // multiplier to get timer clock from PLCK1
 #define LDAC_PWM_PRESCALER   3
+#define LDAC_PWM_HANDLE      htim4
 
 /******************************************************************************/
 /********************** Variables and User Defined Data Types *****************/
@@ -96,6 +97,7 @@ extern struct stm32_pwm_init_param stm32_pwm_extra_init_params;
 extern struct stm32_gpio_init_param stm32_gpio_reset_init_params;
 extern struct stm32_gpio_init_param stm32_clear_gpio_init_params;
 
+extern TIM_HandleTypeDef htim4;
 extern UART_HandleTypeDef huart5;
 extern USBD_HandleTypeDef	APP_UART_USB_HANDLE;
 

--- a/projects/ad7091r_iio/app/app_config_stm32.h
+++ b/projects/ad7091r_iio/app/app_config_stm32.h
@@ -26,7 +26,6 @@
 #include "stm32_i2c.h"
 #include "stm32_gpio_irq.h"
 #include "stm32_dma.h"
-#include "stm32_usb_uart.h"
 #include "app_config.h"
 
 /******************************************************************************/
@@ -41,7 +40,6 @@
 /* STM32 UART specific parameters */
 #define APP_UART_HANDLE     &huart5
 #define UART_IRQ_ID     UART5_IRQn
-#define APP_UART_USB_HANDLE &hUsbDeviceHS
 
 /* GPIO Pins associated with ADC */
 #define RESET_PIN       9  // PG9
@@ -75,6 +73,7 @@
 #define CNV_PWM_ID          1  // Timer 1
 #define CNV_PWM_CHANNEL     3  // Channel 3
 #define CNV_PWM_CLK_DIVIDER 2  // multiplier to get timer clock from PLCK1
+#define CNV_PWM_HANDLE	  	htim1
 #define PWM_GPIO_PORT       CNV_PORT
 #define PWM_GPIO_PIN        CNV_PIN
 
@@ -83,12 +82,14 @@
 #define CS_TIMER_PRESCALER      0
 #define CS_TIMER_CHANNEL        1
 #define TIMER_2_CLK_DIVIDER     2
+#define CS_TIMER_HANDLE         htim2
 
 /* Tx trigger Timer specifc parameters */
 #define TIMER8_ID                          8
 #define TIMER_8_PRESCALER                  0
 #define TIMER_8_CLK_DIVIDER                2
 #define TIMER_CHANNEL_1                    1
+#define TIMER8_HANDLE                      htim8
 
 #define Rx_DMA_IRQ_ID        DMA2_Stream0_IRQn
 #define TxDMA_CHANNEL_NUM    DMA_CHANNEL_7
@@ -109,7 +110,6 @@
 #define tx_trigger_extra_init_params  stm32_tx_trigger_extra_init_params
 #define cs_extra_init_params          stm32_cs_extra_init_params
 #define cs_pwm_gpio_extra_init_params stm32_cs_pwm_gpio_extra_init_params
-#define vcom_extra_init_params      stm32_vcom_extra_init_params
 
 /* Platform Ops */
 #define trigger_gpio_irq_ops    stm32_gpio_irq_ops
@@ -119,7 +119,6 @@
 #define uart_ops                stm32_uart_ops
 #define i2c_ops				    stm32_i2c_ops
 #define dma_ops                 stm32_dma_ops
-#define vcom_ops				stm32_usb_uart_ops
 
 /* Maximum SPI clock rate in Hz */
 #define MAX_SPI_SCLK            40000000
@@ -163,11 +162,11 @@ extern struct stm32_gpio_init_param stm32_gpio_gp0_extra_init_params;
 extern UART_HandleTypeDef huart5;
 extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim2;
-extern USBD_HandleTypeDef hUsbDeviceHS;
 
 #if (INTERFACE_MODE == SPI_DMA)
 extern DMA_HandleTypeDef hdma_tim8_ch1;
 extern DMA_HandleTypeDef hdma_spi1_rx;
+extern TIM_HandleTypeDef htim8;
 extern uint32_t rxdma_ndtr;
 extern uint32_t dma_cycle_count;
 
@@ -176,7 +175,6 @@ extern struct stm32_pwm_init_param stm32_tx_trigger_extra_init_params;
 extern struct stm32_dma_channel rxdma_channel;
 extern struct stm32_dma_channel txdma_channel;
 extern struct stm32_gpio_init_param stm32_cs_pwm_gpio_extra_init_params;
-extern struct stm32_usb_uart_init_param stm32_vcom_extra_init_params;
 
 void receivecomplete_callback(DMA_HandleTypeDef* hdma);
 void halfcmplt_callback(DMA_HandleTypeDef* hdma);

--- a/projects/ad7689_iio/app/app_config_stm32.c
+++ b/projects/ad7689_iio/app/app_config_stm32.c
@@ -67,6 +67,7 @@ struct stm32_gpio_init_param stm32_pwm_gpio_extra_init_params = {
 
 /* STM32 LDAC PWM specific parameters */
 struct stm32_pwm_init_param stm32_pwm_extra_init_params = {
+	.htimer = &PWM_HANDLE,
 	.prescaler = PWM_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,

--- a/projects/ad7689_iio/app/app_config_stm32.h
+++ b/projects/ad7689_iio/app/app_config_stm32.h
@@ -67,6 +67,7 @@
 #define PWM_CHANNEL     1 // Channel 1
 #define PWM_CLK_DIVIDER 2 // multiplier to get timer clock from PLCK1
 #define PWM_PRESCALER   3
+#define PWM_HANDLE      htim4
 
 /* Priority of RDY Interrupt */
 #define RDY_GPIO_PRIORITY 1
@@ -86,7 +87,8 @@
 /******************************************************************************/
 
 extern UART_HandleTypeDef huart5;
-extern USBD_HandleTypeDef	APP_UART_USB_HANDLE;
+extern USBD_HandleTypeDef APP_UART_USB_HANDLE;
+extern TIM_HandleTypeDef PWM_HANDLE;
 
 extern struct stm32_usb_uart_init_param stm32_vcom_extra_init_params;
 extern struct stm32_gpio_irq_init_param stm32_trigger_gpio_irq_init_params;

--- a/projects/ad777x_iio/app/app_config_stm32.c
+++ b/projects/ad777x_iio/app/app_config_stm32.c
@@ -124,6 +124,7 @@ struct stm32_tdm_init_param stm32_tdm_extra_init_params = {
 
 /* STM32 PWM specific parameters */
 struct stm32_pwm_init_param stm32_pwm_extra_init_params = {
+	.htimer = &MCLK_PWM_HANDLE,
 	.prescaler = MCLK_PWM_PRESCALER,
 	.timer_autoreload = true,
 	.mode = TIM_OC_PWM1,

--- a/projects/ad777x_iio/app/app_config_stm32.h
+++ b/projects/ad777x_iio/app/app_config_stm32.h
@@ -85,6 +85,7 @@
 #define MCLK_PWM_PRESCALER  1
 #define MCLK_PWM_CHANNEL    3 // Channel 3
 #define MCLK_PWM_CLK_DIVIDER 2
+#define MCLK_PWM_HANDLE     htim1
 
 /* I2C timing register value for standard mode of operation
  * Check here for more understanding on I2C timing register
@@ -154,6 +155,7 @@ extern struct stm32_tdm_init_param 	stm32_tdm_extra_init_params;
 extern struct stm32_pwm_init_param stm32_pwm_extra_init_params;
 extern struct stm32_i2c_init_param stm32_i2c_extra_init_params;
 extern UART_HandleTypeDef huart3;
+extern TIM_HandleTypeDef htim1;
 extern bool data_capture_operation;
 extern struct iio_device_data *ad777x_iio_dev_data;
 void SystemClock_Config(void);


### PR DESCRIPTION
1. Update no-OS submodule to fetch the latest ad3530r driver changes and timer/pwm related changes.
2. Update relevant stm32_config files accordingly.