### PR TITLE
libraries: Update mbedignore

### DIFF
--- a/libraries/.mbedignore
+++ b/libraries/.mbedignore
@@ -79,6 +79,7 @@ no-OS/drivers/platform/xilinx/
 no-OS/drivers/platform/pico/
 no-OS/drivers/platform/chibios/
 no-OS/drivers/platform/freeRTOS/
+no-OS/drivers/platform/ftd2xx/
 no-OS/drivers/potentiometer/
 no-OS/drivers/power/
 no-OS/drivers/rf-transceiver/


### PR DESCRIPTION
Update mbedignore to exclude the ftd2xx platform drivers