### PR TITLE
projects:evb_discovery_firmware: Correct relative paths

### DIFF
--- a/projects/evb_discovery_firmware/STM32/nucleo_h563/.extSettings
+++ b/projects/evb_discovery_firmware/STM32/nucleo_h563/.extSettings
@@ -1,22 +1,22 @@
 [ProjectFiles]
-HeaderPath=../app;../../../libraries/no-OS/util;../../../libraries/no-OS/include;../../../libraries/no-OS/drivers/platform/stm32;../../../libraries/no-OS/iio;../../../libraries/no-OS/drivers/api;../../../libraries/no-OS/drivers/eeprom/24xx32a/;../../../libraries/precision-converters-library/common/;../../../libraries/precision-converters-library/board_info/;
+HeaderPath=../../app;../../../../libraries/no-OS/util;../../../../libraries/no-OS/include;../../../../libraries/no-OS/drivers/platform/stm32;../../../../libraries/no-OS/iio;../../../../libraries/no-OS/drivers/api;../../../../libraries/no-OS/drivers/eeprom/24xx32a/;../../../../libraries/precision-converters-library/common/;../../../../libraries/precision-converters-library/board_info/;
 
 [Groups]
-app/=../app/main.c;../app/24xx32a_eeprom_iio.c;../app/24xx32a_eeprom_iio.h;../app/app_config.h;../app/app_config.c;../app/app_config_stm32.c;../app/app_config_stm32.h;
+app/=../../app/main.c;../../app/24xx32a_eeprom_iio.c;../../app/24xx32a_eeprom_iio.h;../../app/app_config.h;../../app/app_config.c;../../app/app_config_stm32.c;../../app/app_config_stm32.h;
 
-app/libraries/precision-converters-library/common/=../../../libraries/precision-converters-library/common/common.h;../../../libraries/precision-converters-library/common/common.c;
+app/libraries/precision-converters-library/common/=../../../../libraries/precision-converters-library/common/common.h;../../../../libraries/precision-converters-library/common/common.c;
 
-app/libraries/precision-converters-library/board_info/=../../../libraries/precision-converters-library/board_info/board_info.c;../../../libraries/precision-converters-library/board_info/board_info.h;
+app/libraries/precision-converters-library/board_info/=../../../../libraries/precision-converters-library/board_info/board_info.c;../../../../libraries/precision-converters-library/board_info/board_info.h;
 
-app/libraries/no-OS/drivers/eeprom/24xx32a/=../../../libraries/no-OS/drivers/eeprom/24xx32a/24xx32a.c;../../../libraries/no-OS/drivers/eeprom/24xx32a/24xx32a.h;
+app/libraries/no-OS/drivers/eeprom/24xx32a/=../../../../libraries/no-OS/drivers/eeprom/24xx32a/24xx32a.c;../../../../libraries/no-OS/drivers/eeprom/24xx32a/24xx32a.h;
 
-app/libraries/no-OS/=../../../libraries/no-OS/util/;../../../libraries/no-OS/include;
+app/libraries/no-OS/=../../../../libraries/no-OS/util/;../../../../libraries/no-OS/include;
 
-app/libraries/no-OS/drivers/platform/stm32/=../../../libraries/no-OS/drivers/platform/stm32/stm32_uart.c;../../../libraries/no-OS/drivers/platform/stm32/stm32_uart.h;../../../libraries/no-OS/drivers/platform/stm32/stm32_i2c.h;../../../libraries/no-OS/drivers/platform/stm32/stm32_i2c.c;../../../libraries/no-OS/drivers/platform/stm32/stm32_irq.h;../../../libraries/no-OS/drivers/platform/stm32/stm32_irq.c;../../../libraries/no-OS/drivers/platform/stm32/stm32_delay.c
+app/libraries/no-OS/drivers/platform/stm32/=../../../../libraries/no-OS/drivers/platform/stm32/stm32_uart.c;../../../../libraries/no-OS/drivers/platform/stm32/stm32_uart.h;../../../../libraries/no-OS/drivers/platform/stm32/stm32_i2c.h;../../../../libraries/no-OS/drivers/platform/stm32/stm32_i2c.c;../../../../libraries/no-OS/drivers/platform/stm32/stm32_irq.h;../../../../libraries/no-OS/drivers/platform/stm32/stm32_irq.c;../../../../libraries/no-OS/drivers/platform/stm32/stm32_delay.c
 
-app/libraries/no-OS/iio/=../../../libraries/no-OS/iio/iio.c;../../../libraries/no-OS/iio/iio.h;../../../libraries/no-OS/iio/iiod.h;../../../libraries/no-OS/iio/iiod.c;
+app/libraries/no-OS/iio/=../../../../libraries/no-OS/iio/iio.c;../../../../libraries/no-OS/iio/iio.h;../../../../libraries/no-OS/iio/iiod.h;../../../../libraries/no-OS/iio/iiod.c;
 
-app/libraries/no-OS/drivers/api/=../../../libraries/no-OS/drivers/api/no_os_uart.c;../../../libraries/no-OS/drivers/api/no_os_i2c.c;../../../libraries/no-OS/drivers/api/no_os_eeprom.c;../../../libraries/no-OS/drivers/api/no_os_irq.c;
+app/libraries/no-OS/drivers/api/=../../../../libraries/no-OS/drivers/api/no_os_uart.c;../../../../libraries/no-OS/drivers/api/no_os_i2c.c;../../../../libraries/no-OS/drivers/api/no_os_eeprom.c;../../../../libraries/no-OS/drivers/api/no_os_irq.c;
 
 [Others]
 Define=_USE_STD_INT_TYPES;TINYIIOD_VERSION_MAJOR;TINYIIOD_VERSION_MINOR;TINYIIOD_VERSION_GIT;IIOD_BUFFER_SIZE;IIO_IGNORE_BUFF_OVERRUN_ERR;USE_PHY_COM_PORT;ACTIVE_PLATFORM:2


### PR DESCRIPTION
Correct relative paths to the dependent files in the .extsettings