### PR TITLE
projects:ad4170_iio: Updates to AD4170 IIO Application

### DIFF
--- a/projects/ad4170_iio/app/app_config.c
+++ b/projects/ad4170_iio/app/app_config.c
@@ -27,6 +27,7 @@
 #include "no_os_eeprom.h"
 #include "no_os_tdm.h"
 #include "no_os_pwm.h"
+#include "no_os_delay.h"
 #if (ACTIVE_IIO_CLIENT == IIO_CLIENT_LOCAL)
 #include "pl_gui_events.h"
 #include "pl_gui_views.h"
@@ -409,9 +410,6 @@ int32_t init_system(void)
 	stm32_system_init();
 #endif
 
-	/* Delay to ensure that the peripherals are initialized */
-	no_os_mdelay(2000);
-
 	ret = init_gpio();
 	if (ret) {
 		return ret;
@@ -421,6 +419,9 @@ int32_t init_system(void)
 	if (ret) {
 		return ret;
 	}
+
+	/* Delay to ensure that the peripherals are initialized */
+	no_os_mdelay(2000);
 
 	ret = gpio_trigger_init();
 	if (ret) {

--- a/projects/ad4170_iio/app/app_config_stm32.c
+++ b/projects/ad4170_iio/app/app_config_stm32.c
@@ -292,7 +292,7 @@ void ad4170_spi_dma_rx_cplt_callback(DMA_HandleTypeDef* hdma)
 #else // CONTUNUOUS_DATA_CAPTURE
 	no_os_cb_end_async_write(iio_dev_data_g->buffer->buf);
 	no_os_cb_prepare_async_write(iio_dev_data_g->buffer->buf,
-				     nb_of_samples_g * (BYTES_PER_SAMPLE), &buff_start_addr, &data_read);
+				     nb_of_samples_g, &buff_start_addr, &data_read);
 #endif // DATA_CAPTURE_MODE
 #endif // INTERFACE_MODE
 }
@@ -419,7 +419,9 @@ void DMA2_Stream0_IRQHandler(void)
 	if (callback_count == 1) {
 		HAL_GPIO_WritePin(SYNC_INB_PORT_ID, 1 << SYNC_INB, GPIO_PIN_RESET);
 	}
+#else
+	memcpy(iio_buf_current_idx,
+	       dma_buf_current_idx, rxdma_ndtr);
 #endif
-
 	HAL_DMA_IRQHandler(&hdma_spi1_rx);
 }


### PR DESCRIPTION
1) Add ping pong buffer for Continuous DMA Mode
2) Update filter for all channels when changed via attribute 3) Move the delay function after UART Initialization 4) Correct the number of samples in the no_os_prepare_async function