### PR TITLE
Ad405x refactor

### DIFF
--- a/projects/ad405x_iio/STM32/sdp_k1/.extSettings
+++ b/projects/ad405x_iio/STM32/sdp_k1/.extSettings
@@ -2,7 +2,7 @@
 HeaderPath=../../app;../../../../libraries/no-OS/util;../../../../libraries/no-OS/include;../../../../libraries/no-OS/drivers/platform/stm32;../../../../libraries/no-OS/iio;../../../../libraries/no-OS/drivers/api;../../../../libraries/precision-converters-library/board_info/;../../../../libraries/no-OS/drivers/eeprom/24xx32a/;../../../../libraries/precision-converters-library/sdp_k1_sdram/;../../../../libraries/precision-converters-library/common/;../../../../libraries/no-OS/drivers/adc/ad405x/;
 
 [Groups]
-app/=../../app/main.c;../../app/ad405x_iio.c;../../app/ad405x_iio.h;../../app/app_config.h;../../app/app_config.c;../../app/app_config_stm32.c;../../app/app_config_stm32.h;../../app/stm32_gpio_irq_generated.c;../../app/ad405x_user_config.c;../../app/ad405x_user_config.h;
+app/=../../app/main.c;../../app/ad405x_iio.c;../../app/ad405x_iio.h;../../app/app_config.h;../../app/app_config.c;../../app/app_config_stm32.c;../../app/app_config_stm32.h;../../app/stm32_gpio_irq_generated.c;../../app/ad405x_user_config.c;../../app/ad405x_user_config.h;../../app/app_support.h;../../app/app_support.c;../../app/ad405x_support.c;
 
 app/libraries/precision-converters-library/board_info/=../../../../libraries/precision-converters-library/board_info/board_info.c;../../../../libraries/precision-converters-library/board_info/board_info.h;
 

--- a/projects/ad405x_iio/app/ad405x_iio.c
+++ b/projects/ad405x_iio/app/ad405x_iio.c
@@ -92,38 +92,13 @@ static int8_t adc_data_buffer[DATA_BUFFER_SIZE];
 /* Factor multiplied to calculated conversion time to ensure proper data capture */
 #define COMPENSATION_FACTOR	1.1
 
-/* Internal sampling frequency/period (2msps->500nsec) */
-#define INTERNAL_SAMPLING_CLK_NS     500
-
 /* Internal conversion time in nsec */
 #define CONVERSION_TIME_NS           250
-
-#define MAX_SAMPLING_TIME_NS          (((float)(1.0/SAMPLING_RATE) * 1000000000) / 2)
 
 #define MAX_SAMPLING_PERIOD_NSEC		2500000
 
 /* Converts pwm period in nanoseconds to sampling frequency in samples per second */
 #define PWM_PERIOD_TO_FREQUENCY(x)       (1000000000.0 / x)
-
-/* Timeout count to avoid stuck into potential infinite loop while checking
- * for new data whenever the BUSY pin goes low. The actual timeout factor is determined
- * through 'sampling_frequency' attribute of IIO app, but this period here makes sure
- * we are not stuck into a forever loop in case data capture is interrupted
- * or failed in between.
- * Note: This timeout factor is dependent upon the MCU clock frequency. Below timeout
- * is tested for SDP-K1 platform @180Mhz default core clock */
-#define BUF_READ_TIMEOUT	0xffffffff
-
-/* Number of samples after which the circular buffer indexes are
- * are updated for continuous mode with SPI DMA
- */
-#define BUFFER_UPDATE_RATE  400
-
-/* Maximum size of the local SRAM buffer */
-#define MAX_LOCAL_BUF_SIZE	32000
-
-/* Maximum value the DMA NDTR register can take */
-#define MAX_DMA_NDTR		(no_os_min(65535, MAX_LOCAL_BUF_SIZE/2))
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -1168,8 +1143,8 @@ int32_t iio_ad405x_initialize(void)
 	int32_t init_status;
 	enum ad405x_device_type dev_type;
 	uint8_t indx;
-	static bool entered =
-		false;  // Flag to control the execution of system initialization
+	/* Flag to control the execution of system initialization */
+	static bool entered = false;
 
 #if	(APP_CAPTURE_MODE == CONTINUOUS_DATA_CAPTURE)
 	static struct iio_trigger ad405x_iio_trig_desc = {

--- a/projects/ad405x_iio/app/ad405x_support.c
+++ b/projects/ad405x_iio/app/ad405x_support.c
@@ -1,0 +1,550 @@
+/***************************************************************************//**
+ *   @file    ad405x_support.c
+ *   @brief   Implementation of AD405x support functions
+ *   @details This module has all the support file necessary for working of AD405x
+********************************************************************************
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+
+#include "iio.h"
+#include "iio_trigger.h"
+#include "app_support.h"
+#include "ad405x_iio.h"
+#include "ad405x_user_config.h"
+
+#include "no_os_error.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definition ***********************/
+/******************************************************************************/
+
+/* Maximum size of the local SRAM buffer */
+#define MAX_LOCAL_BUF_SIZE	32000
+
+/* Maximum value the DMA NDTR register can take */
+#define MAX_DMA_NDTR		(no_os_min(65535, MAX_LOCAL_BUF_SIZE/2))
+
+/******************************************************************************/
+/********************** Variables and User Defined Data Types *****************/
+/******************************************************************************/
+
+/* Local SRAM buffer */
+uint8_t local_buf[MAX_LOCAL_BUF_SIZE];
+
+/* Flag to indicate if DMA has been configured for windowed capture */
+static volatile bool dma_config_updated = false;
+
+/* Flag to indicate if size of the buffer is updated according to requested
+ * number of samples for the multi-channel IIO buffer data alignment */
+static volatile bool buf_size_updated = false;
+
+/* ad405x IIO hw trigger descriptor */
+extern struct iio_hw_trig *ad405x_hw_trig_desc;
+
+extern uint8_t bytes_per_sample;
+
+#if APP_CAPTURE_MODE == WINDOWED_DATA_CAPTURE
+
+/**
+ * @brief  Prepares the device for data transfer.
+ * @param  dev[in, out]- Application descriptor.
+ * @param  mask[in]- Number of bytes to transfer.
+ * @return 0 in case of success, error code otherwise.
+ */
+static int32_t ad405x_pre_enable_windowed(void *dev, uint32_t mask)
+{
+	int32_t ret;
+	/* SPI init params */
+	struct stm32_spi_init_param* spi_init_param;
+
+	if (ad405x_interface_mode == SPI_DMA) {
+		ret = ad405x_set_operation_mode(p_ad405x_dev, ad405x_operating_mode);
+		if (ret) {
+			return ret;
+		}
+
+		/* Switch to faster SPI SCLK and
+		 * initialize Chip Select PWMs and DMA descriptors */
+		ad405x_init_params.spi_init->max_speed_hz = MAX_SPI_SCLK_45MHz;
+		spi_init_param = ad405x_init_params.spi_init->extra;
+		spi_init_param->pwm_init = (const struct no_os_pwm_init_param *)&cs_init_params;
+		spi_init_param->dma_init = &ad405x_dma_init_param;
+		spi_init_param->irq_num = Rx_DMA_IRQ_ID;
+		spi_init_param->rxdma_ch = &rxdma_channel;
+		spi_init_param->txdma_ch = &txdma_channel;
+
+		ret = no_os_spi_init(&p_ad405x_dev->spi_desc, ad405x_init_params.spi_init);
+		if (ret) {
+			return ret;
+		}
+
+		/* Use 16-bit SPI Data Frame Format during data capture */
+		stm32_config_spi_data_frame_format(true);
+
+		/* Configure CS and CNV gpios for alternate functionality as
+		 * Timer PWM outputs */
+		stm32_cs_output_gpio_config(false);
+
+		ret = init_pwm();
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief  Terminate current data transfer.
+ * @param  dev[in, out]- Application descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t ad405x_post_disable_windowed(void *dev)
+{
+	int32_t ret;
+	/* SPI init params */
+	struct stm32_spi_init_param* spi_init_param;
+
+	if (ad405x_interface_mode == SPI_DMA) {
+		/* Revert to 8-bit SPI Data Frame Format after data capture */
+		stm32_config_spi_data_frame_format(false);
+
+		/* Abort DMA and Timers and configure CS and CNV as GPIOs */
+		stm32_timer_stop();
+		stm32_abort_dma_transfer();
+		stm32_cs_output_gpio_config(true);
+
+		spi_init_param = ad405x_init_params.spi_init->extra;
+		spi_init_param->dma_init = NULL;
+		ad405x_init_params.spi_init->max_speed_hz = MAX_SPI_SCLK;
+		ret = no_os_spi_init(&p_ad405x_dev->spi_desc, ad405x_init_params.spi_init);
+		if (ret) {
+			return ret;
+		}
+
+		dma_config_updated = false;
+		buf_size_updated = false;
+
+		ret = ad405x_exit_command(p_ad405x_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Writes all the samples from the ADC buffer into the
+		  IIO buffer.
+ * @param iio_dev_data[in] - IIO device data instance.
+ * @return Number of samples read.
+ */
+static int32_t ad405x_submit_windowed(struct iio_device_data *iio_dev_data)
+{
+	uint32_t timeout = BUF_READ_TIMEOUT;
+	uint32_t sample_index = 0;
+	int32_t adc_data;
+	int32_t ret;
+	uint16_t spirxdma_ndtr;
+	uint32_t nb_of_samples;
+
+	data_ready = false;
+	nb_of_samples = iio_dev_data->buffer->size / bytes_per_sample;
+	nb_of_bytes_g = nb_of_samples * bytes_per_sample;
+	iio_dev_data_g = iio_dev_data;
+
+	if (!buf_size_updated) {
+		/* Update total buffer size according to bytes per scan for proper
+		 * alignment of multi-channel IIO buffer data */
+		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
+		buf_size_updated = true;
+	}
+
+	if (ad405x_interface_mode == SPI_INTR) {
+		ret = ad405x_set_operation_mode(p_ad405x_dev, ad405x_operating_mode);
+		if (ret) {
+			return ret;
+		}
+		ret = init_pwm();
+		if (ret) {
+			return ret;
+		}
+		ret = no_os_pwm_enable(pwm_desc);
+		if (ret) {
+			return ret;
+		}
+
+		/*
+		 * Clear any pending event that occurs from a unintended
+		 * falling edge of busy pin before enabling the interrupt
+		 */
+		ret = no_os_irq_clear_pending(trigger_irq_desc, TRIGGER_INT_ID);
+		if (ret) {
+			return ret;
+		}
+
+		ret = no_os_irq_enable(trigger_irq_desc, TRIGGER_INT_ID);
+		if (ret) {
+			return ret;
+		}
+
+		while (sample_index < nb_of_samples) {
+			while (data_ready != true && timeout > 0) {
+				timeout--;
+			}
+
+			if (!timeout) {
+				return -EIO;
+			}
+
+			ret = ad405x_spi_data_read(p_ad405x_dev, &adc_data);
+			if (ret) {
+				return ret;
+			}
+
+			ret = no_os_cb_write(iio_dev_data->buffer->buf, &adc_data, bytes_per_sample);
+			if (ret) {
+				return ret;
+			}
+
+			sample_index++;
+			data_ready = false;
+		}
+
+		ret = no_os_pwm_disable(pwm_desc);
+		if (ret) {
+			return ret;
+		}
+
+		ret = no_os_irq_disable(trigger_irq_desc, TRIGGER_INT_ID);
+		if (ret) {
+			return ret;
+		}
+
+		buf_size_updated = false;
+
+		ret = ad405x_exit_command(p_ad405x_dev);
+		if (ret) {
+			return ret;
+		}
+	} else {
+		ret = no_os_cb_prepare_async_write(iio_dev_data->buffer->buf,
+						   nb_of_samples * (bytes_per_sample),
+						   (void **) &buff_start_addr,
+						   &data_read);
+		if (ret) {
+			return ret;
+		}
+
+		if (!dma_config_updated) {
+			/* Cap SPI RX DMA NDTR to MAX_DMA_NDTR. */
+			spirxdma_ndtr = no_os_min(MAX_DMA_NDTR, nb_of_samples);
+			rxdma_ndtr = spirxdma_ndtr;
+
+			/* Register half complete callback, for ping-pong buffers implementation. */
+			HAL_DMA_RegisterCallback(&hdma_spi1_rx,
+						 HAL_DMA_XFER_HALFCPLT_CB_ID,
+						 halfcmplt_callback);
+
+			struct no_os_spi_msg ad405x_spi_msg = {
+				.tx_buff = NULL,
+				.rx_buff = local_buf,
+				.bytes_number = spirxdma_ndtr
+			};
+
+			struct stm32_spi_desc *sdesc = p_ad405x_dev->spi_desc->extra;
+			ret = no_os_spi_transfer_dma_async(p_ad405x_dev->spi_desc,
+							   &ad405x_spi_msg,
+							   1,
+							   NULL,
+							   NULL);
+			if (ret) {
+				return ret;
+			}
+
+			/* Disable CS PWM and reset the counters */
+			no_os_pwm_disable(sdesc->pwm_desc); // CS PWM
+			htim2.Instance->CNT = 0;
+			htim1.Instance->CNT = 0;
+			TIM8->CNT = 0;
+
+			dma_config_updated = true;
+		}
+
+		ad405x_conversion_flag = false;
+
+		dma_cycle_count = ((nb_of_samples) / rxdma_ndtr) + 1;
+
+		/* Set the callback count to twice the number of DMA cycles */
+		callback_count = dma_cycle_count * 2;
+
+		update_buff(local_buf, (uint8_t *)buff_start_addr);
+		stm32_timer_enable();
+
+		while (ad405x_conversion_flag != true && timeout > 0) {
+			timeout--;
+		}
+
+		if (!timeout) {
+			return -EIO;
+		}
+
+		no_os_cb_end_async_write(iio_dev_data->buffer->buf);
+	}
+
+	return 0;
+}
+
+#endif
+
+#if APP_CAPTURE_MODE == CONTINUOUS_DATA_CAPTURE
+
+/**
+ * @brief  Prepares the device for data transfer.
+ * @param  dev[in, out]- Application descriptor.
+ * @param  mask[in]- Number of bytes to transfer.
+ * @return 0 in case of success, error code otherwise.
+ */
+static int32_t ad405x_pre_enable_continuous(void *dev, uint32_t mask)
+{
+	int32_t ret;
+	/* SPI init params */
+	struct stm32_spi_init_param* spi_init_param;
+
+	ret = ad405x_set_operation_mode(p_ad405x_dev, ad405x_operating_mode);
+	if (ret) {
+		return ret;
+	}
+
+	if (ad405x_interface_mode == SPI_INTR) {
+		ret = init_pwm();
+		if (ret) {
+			return ret;
+		}
+
+		ret = no_os_pwm_enable(pwm_desc);
+		if (ret) {
+			return ret;
+		}
+
+		/* Clear any pending event that occurs from a unintended
+		 * falling edge of busy pin before enabling the interrupt
+		 */
+		ret = no_os_irq_clear_pending(ad405x_hw_trig_desc->irq_ctrl,
+					      ad405x_hw_trig_desc->irq_id);
+		if (ret) {
+			return ret;
+		}
+
+		ret = iio_trig_enable(ad405x_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+	} else {
+
+		/* Switch to faster SPI SCLK and
+		 * initialize Chip Select PWMs and DMA descriptors */
+		ad405x_init_params.spi_init->max_speed_hz = MAX_SPI_SCLK_45MHz;
+		spi_init_param = ad405x_init_params.spi_init->extra;
+		spi_init_param->pwm_init = (const struct no_os_pwm_init_param *)&cs_init_params;
+		spi_init_param->dma_init = &ad405x_dma_init_param;
+		spi_init_param->irq_num = Rx_DMA_IRQ_ID;
+		spi_init_param->rxdma_ch = &rxdma_channel;
+		spi_init_param->txdma_ch = &txdma_channel;
+
+		ret = no_os_spi_init(&p_ad405x_dev->spi_desc, ad405x_init_params.spi_init);
+		if (ret) {
+			return ret;
+		}
+
+		/* Use 16-bit SPI Data Frame Format during data capture */
+		stm32_config_spi_data_frame_format(true);
+
+		/* Configure CS and CNV gpios for alternate functionality as
+		 * Timer PWM outputs */
+		stm32_cs_output_gpio_config(false);
+
+		ret = init_pwm();
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief  Terminate current data transfer.
+ * @param  dev[in, out]- Application descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t ad405x_post_disable_continuous(void *dev)
+{
+	int32_t ret;
+
+	if (ad405x_interface_mode == SPI_DMA) {
+		/* SPI init params */
+		struct stm32_spi_init_param *spi_init_param;
+
+		/* Revert to 8-bit SPI Data Frame Format after data capture */
+		stm32_config_spi_data_frame_format(false);
+
+		/* Abort DMA and Timers and configure CS and CNV as GPIOs */
+		stm32_timer_stop();
+		stm32_abort_dma_transfer();
+		stm32_cs_output_gpio_config(true);
+
+		spi_init_param = ad405x_init_params.spi_init->extra;
+		spi_init_param->dma_init = NULL;
+		ad405x_init_params.spi_init->max_speed_hz = MAX_SPI_SCLK;
+		ret = no_os_spi_init(&p_ad405x_dev->spi_desc, ad405x_init_params.spi_init);
+		if (ret) {
+			return ret;
+		}
+
+		dma_config_updated = false;
+
+	} else {
+		ret = no_os_pwm_disable(pwm_desc);
+		if (ret) {
+			return ret;
+		}
+
+		ret = iio_trig_disable(ad405x_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	buf_size_updated = false;
+
+	ret = ad405x_exit_command(p_ad405x_dev);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Writes all the samples from the ADC buffer into the
+		  IIO buffer.
+ * @param iio_dev_data[in] - IIO device data instance.
+ * @return Number of samples read.
+ */
+static int32_t ad405x_submit_continuous(struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+	uint16_t spirxdma_ndtr;
+	uint32_t nb_of_samples;
+
+	data_ready = false;
+	nb_of_samples = iio_dev_data->buffer->size / bytes_per_sample;
+	nb_of_bytes_g = nb_of_samples * bytes_per_sample;
+	iio_dev_data_g = iio_dev_data;
+
+	/* Cap SPI RX DMA NDTR to MAX_DMA_NDTR. */
+	spirxdma_ndtr = no_os_min(MAX_DMA_NDTR, nb_of_samples);
+	rxdma_ndtr = spirxdma_ndtr;
+
+	if (!buf_size_updated) {
+		/* Update total buffer size according to bytes per scan for proper
+		 * alignment of multi-channel IIO buffer data */
+		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
+		buf_size_updated = true;
+	}
+
+	if (!dma_config_updated) {
+		ret = no_os_cb_prepare_async_write(iio_dev_data->buffer->buf,
+						   nb_of_samples * (bytes_per_sample),
+						   (void **) &buff_start_addr,
+						   &data_read);
+		if (ret) {
+			return ret;
+		}
+
+		struct no_os_spi_msg ad405x_spi_msg = {
+			.tx_buff = NULL,
+			.rx_buff = (uint8_t *)buff_start_addr,
+			.bytes_number = spirxdma_ndtr
+		};
+
+		ret = no_os_spi_transfer_dma_async(p_ad405x_dev->spi_desc,
+						   &ad405x_spi_msg,
+						   1,
+						   NULL,
+						   NULL);
+		if (ret) {
+			return ret;
+		}
+		struct stm32_spi_desc* sdesc = p_ad405x_dev->spi_desc->extra;
+		no_os_pwm_disable(sdesc->pwm_desc); // CS PWM
+		htim2.Instance->CNT = 0;
+		htim1.Instance->CNT = 0;
+		TIM8->CNT = 0;
+		dma_config_updated = true;
+
+		stm32_timer_enable();
+	}
+
+	return 0;
+}
+
+/**
+ * @brief	Reads data from the ADC and pushes it into IIO buffer when the
+			IRQ is triggered.
+ * @param	iio_dev_data[in] - IIO device data instance.
+ * @return	0 in case of success or negative value otherwise.
+ */
+static int32_t ad405x_trigger_handler_continuous(struct iio_device_data
+		*iio_dev_data)
+{
+	int32_t ret;
+	int32_t adc_data;
+
+	if (!buf_size_updated) {
+		/* Update total buffer size according to bytes per scan for proper
+		 * alignment of multi-channel IIO buffer data */
+		iio_dev_data->buffer->buf->size = ((uint32_t)(DATA_BUFFER_SIZE /
+						   iio_dev_data->buffer->bytes_per_scan)) * iio_dev_data->buffer->bytes_per_scan;
+		buf_size_updated = true;
+	}
+
+	/* Read the sample for channel which has been sampled recently */
+	ret = ad405x_spi_data_read(p_ad405x_dev, &adc_data);
+	if (ret) {
+		return ret;
+	}
+
+	return no_os_cb_write(iio_dev_data->buffer->buf, &adc_data, bytes_per_sample);
+}
+
+#endif
+
+
+#if APP_CAPTURE_MODE == WINDOWED_DATA_CAPTURE
+const struct ad405x_support_desc ad405x_support_descriptor = {
+	.submit = ad405x_submit_windowed,
+	.pre_enable = ad405x_pre_enable_windowed,
+	.post_disable = ad405x_post_disable_windowed,
+	.trigger_handler = NULL
+};
+#endif
+#if APP_CAPTURE_MODE == CONTINUOUS_DATA_CAPTURE
+const struct ad405x_support_desc ad405x_support_descriptor = {
+	.submit = ad405x_submit_continuous,
+	.pre_enable = ad405x_pre_enable_continuous,
+	.post_disable = ad405x_post_disable_continuous,
+	.trigger_handler = ad405x_trigger_handler_continuous
+};
+#endif

--- a/projects/ad405x_iio/app/app_config.c
+++ b/projects/ad405x_iio/app/app_config.c
@@ -22,7 +22,6 @@
 #include "no_os_delay.h"
 #include "no_os_i2c.h"
 #include "no_os_dma.h"
-#include "stm32_dma.h"
 
 /******************************************************************************/
 /************************ Macros/Constants ************************************/
@@ -147,6 +146,7 @@ struct no_os_pwm_init_param tx_trigger_init_params = {
 	.extra = &tx_trigger_extra_init_params,
 };
 
+#if (APP_CAPTURE_MODE == WINDOWED_DATA_CAPTURE)
 /* External interrupt callback descriptor */
 static struct no_os_callback_desc ext_int_callback_desc = {
 	.callback = data_capture_callback,
@@ -154,6 +154,7 @@ static struct no_os_callback_desc ext_int_callback_desc = {
 	.event = NO_OS_EVT_GPIO,
 	.peripheral = NO_OS_GPIO_IRQ
 };
+#endif
 
 /* I2C init parameters */
 static struct no_os_i2c_init_param no_os_i2c_init_params = {

--- a/projects/ad405x_iio/app/app_config.h
+++ b/projects/ad405x_iio/app/app_config.h
@@ -60,9 +60,9 @@
 #define USE_VIRTUAL_COM_PORT
 #endif
 
-/* Select the application data capture mode (default is CC mode) */
+/* Select the application data capture mode (default is Windowed mode) */
 #if !defined(APP_CAPTURE_MODE)
-#define APP_CAPTURE_MODE	   CONTINUOUS_DATA_CAPTURE
+#define APP_CAPTURE_MODE	   WINDOWED_DATA_CAPTURE
 #endif
 
 /* Select the ADC output data format (default is twos complement mode) */

--- a/projects/ad405x_iio/app/app_config.h
+++ b/projects/ad405x_iio/app/app_config.h
@@ -22,6 +22,7 @@
 #include "no_os_uart.h"
 #include "no_os_irq.h"
 #include "no_os_pwm.h"
+#include "common.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definition ***********************/
@@ -49,6 +50,9 @@
 #define ACTIVE_PLATFORM		STM32_PLATFORM
 #endif
 
+/* Enable/Disable the use of SDRAM for ADC data capture buffer */
+//#define USE_SDRAM	// Uncomment to use SDRAM as data buffer
+
 /* Enable the UART/VirtualCOM port connection (default VCOM) */
 //#define USE_PHY_COM_PORT		// Uncomment to select UART
 
@@ -58,7 +62,7 @@
 
 /* Select the application data capture mode (default is CC mode) */
 #if !defined(APP_CAPTURE_MODE)
-#define APP_CAPTURE_MODE	   WINDOWED_DATA_CAPTURE
+#define APP_CAPTURE_MODE	   CONTINUOUS_DATA_CAPTURE
 #endif
 
 /* Select the ADC output data format (default is twos complement mode) */
@@ -119,8 +123,25 @@
 /* Serial number string is formed as: application name + device (target) name + platform (host) name */
 #define VIRTUAL_COM_SERIAL_NUM	(FIRMWARE_NAME "_" DEVICE_NAME "_" STR(PLATFORM_NAME))
 
-/* Enable/Disable the use of SDRAM for ADC data capture buffer */
-//#define USE_SDRAM	// Uncomment to use SDRAM as data buffer
+/* ADC data buffer size */
+#if defined(USE_SDRAM)
+#define DATA_BUFFER_SIZE			SDRAM_SIZE_BYTES
+#else
+#define DATA_BUFFER_SIZE			(131072)		// 128kbytes
+#endif
+
+/******************************************************************************/
+
+#define STORAGE_BITS_SAMPLE 16
+#define AD4050_SAMPLE_RES   12
+#define AD4052_SAMPLE_RES   16
+
+#define STORAGE_BITS_AVG    32
+#define AD4050_AVG_RES      14
+#define AD4052_AVG_RES      20
+
+/* Number of storage bytes for each sample */
+#define BYTES_PER_SAMPLE(x)   (x/8)
 
 /******************************************************************************/
 /********************** Variables and User Defined Data Types *****************/

--- a/projects/ad405x_iio/app/app_config_stm32.c
+++ b/projects/ad405x_iio/app/app_config_stm32.c
@@ -356,7 +356,7 @@ void receivecomplete_callback(DMA_HandleTypeDef * hdma)
 	no_os_cb_end_async_write(iio_dev_data_g->buffer->buf);
 	no_os_cb_prepare_async_write(iio_dev_data_g->buffer->buf,
 				     nb_of_bytes_g,
-				     &buff_start_addr,
+				     (void **) &buff_start_addr,
 				     &data_read);
 #endif
 }
@@ -378,24 +378,6 @@ void stm32_cs_output_gpio_config(bool is_gpio)
 
 	no_os_gpio_get(&cs_gpio_desc, &cs_pwm_gpio_params);
 
-}
-
-/**
- * @brief 	Configures the conversion pin as output mode.
- * @param   is_gpio[in] Mode of the Pin
- * @return	None
- */
-void stm32_cnv_output_gpio_config(bool is_gpio)
-{
-	struct no_os_gpio_desc* cnv_gpio_desc;
-
-	if (is_gpio) {
-		pwm_gpio_params.extra = &stm32_gpio_cnv_extra_init_params;
-
-	} else {
-		pwm_gpio_params.extra = &stm32_pwm_gpio_extra_init_params;
-	}
-	no_os_gpio_get(&cnv_gpio_desc, &pwm_gpio_params);
 }
 
 /**

--- a/projects/ad405x_iio/app/app_config_stm32.h
+++ b/projects/ad405x_iio/app/app_config_stm32.h
@@ -134,10 +134,6 @@
 #endif
 #define CONV_TRIGGER_DUTY_CYCLE_NSEC(x)	   (x / 10)
 #define SAMPLING_RATE_SPI_DMA			   (1000000)
-#define DMA_MSB_DUTY_CYCLE_NS              200
-#define DMA_LSB_DUTY_CYCLE_NS              600
-#define OUTPUT_COMPARE_DUTY_CYCLE_NS       200
-#define CHIP_SELECT_DUTY_CYCLE_NS          800
 #define CONV_TRIGGER_PERIOD_NSEC(x)		   (((float)(1.0 / x) * 1000000) * 1000)
 
 /******************************************************************************/
@@ -145,12 +141,11 @@
 /******************************************************************************/
 extern I2C_HandleTypeDef hi2c1;
 extern SPI_HandleTypeDef hspi1;
-extern DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim8;
+extern DMA_HandleTypeDef hdma_spi1_rx;
 extern DMA_HandleTypeDef hdma_tim1_ch3;
-extern DMA_HandleTypeDef hdma_tim1_ch2;
 extern DMA_HandleTypeDef hdma_tim8_ch1;
 extern UART_HandleTypeDef huart5;
 extern USBD_HandleTypeDef hUsbDeviceHS;
@@ -168,7 +163,6 @@ extern struct stm32_gpio_irq_init_param stm32_gpio_irq_extra_init_params;
 
 extern struct stm32_pwm_init_param stm32_pwm_cnv_extra_init_params;
 extern struct stm32_pwm_init_param stm32_dma_extra_init_params;
-extern struct stm32_pwm_init_param stm32_oc_extra_init_params;
 extern struct stm32_pwm_init_param stm32_cs_extra_init_params;
 extern struct stm32_pwm_init_param stm32_tx_trigger_extra_init_params;
 extern volatile bool ad405x_conversion_flag;
@@ -185,7 +179,6 @@ void stm32_system_init(void);
 void stm32_timer_enable(void);
 void stm32_timer_stop(void);
 void stm32_cs_output_gpio_config(bool is_gpio);
-void stm32_cnv_output_gpio_config(bool is_gpio);
 void stm32_config_spi_data_frame_format(bool is_16_bit);
 void stm32_config_cnv_prescalar(void);
 int stm32_abort_dma_transfer(void);

--- a/projects/ad405x_iio/app/app_config_stm32.h
+++ b/projects/ad405x_iio/app/app_config_stm32.h
@@ -22,16 +22,22 @@
 #include "stm32_i2c.h"
 #include "stm32_irq.h"
 #include "stm32_gpio_irq.h"
-#include "stm32_spi.h"
 #include "stm32_gpio.h"
 #include "stm32_uart.h"
 #include "stm32_dma.h"
 #include "stm32_pwm.h"
+
+#ifdef STM32F469xx
+#include "stm32_spi.h"
 #include "stm32_usb_uart.h"
+#endif
 
 /******************************************************************************/
 /********************** Macros and Constants Definition ***********************/
 /******************************************************************************/
+
+#ifdef STM32F469xx
+
 /* Note: The SDP-K1 board with the STM32F469NI MCU has been used
 * for developing the firmware. The below parameters will change depending
 * on the controller used. */
@@ -84,6 +90,8 @@
 #define AD405x_TxDMA_CHANNEL_NUM    DMA_CHANNEL_7
 #define AD405x_RxDMA_CHANNEL_NUM    DMA_CHANNEL_3
 #define Rx_DMA_IRQ_ID           DMA2_Stream0_IRQn
+
+#endif
 
 /* Redefine the init params structure mapping w.r.t. platform */
 #define uart_extra_init_params      stm32_uart_extra_init_params

--- a/projects/ad405x_iio/app/app_support.c
+++ b/projects/ad405x_iio/app/app_support.c
@@ -1,0 +1,39 @@
+/***************************************************************************//**
+ *   @file    app_support.c
+ *   @brief   Implementation of Application support functions
+ *   @details This module has all the support file necessary for working of app
+********************************************************************************
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+
+#include "ad405x.h"
+#include "app_config.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definition ***********************/
+/******************************************************************************/
+
+extern const struct ad405x_support_desc ad405x_support_descriptor;
+
+/******************************************************************************/
+/********************** Variables and User Defined Data Types *****************/
+/******************************************************************************/
+const struct ad405x_support_desc *support_desc[] =  {
+	[ID_AD4050] = &ad405x_support_descriptor,
+	[ID_AD4052] = &ad405x_support_descriptor
+};
+
+/* Global variable for number of samples */
+uint32_t nb_of_bytes_g;
+
+/* Global variable for data read from CB functions */
+uint32_t data_read;

--- a/projects/ad405x_iio/app/app_support.h
+++ b/projects/ad405x_iio/app/app_support.h
@@ -1,0 +1,53 @@
+/***************************************************************************//**
+ *   @file    app_support.h
+ *   @brief   Implementation of AD405x support functions
+ *   @details This module has all the support file necessary for working of AD405x
+********************************************************************************
+ * Copyright (c) 2022-2025 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+#ifndef AD405X_SUPPORT_H_
+#define AD405X_SUPPORT_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+
+#include "iio.h"
+#include "app_config.h"
+#include "ad405x.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definition ***********************/
+/******************************************************************************/
+/* Timeout count to avoid stuck into potential infinite loop while checking
+ * for new data whenever the BUSY pin goes low. The actual timeout factor is determined
+ * through 'sampling_frequency' attribute of IIO app, but this period here makes sure
+ * we are not stuck into a forever loop in case data capture is interrupted
+ * or failed in between.
+ * Note: This timeout factor is dependent upon the MCU clock frequency. Below timeout
+ * is tested for SDP-K1 platform @180Mhz default core clock */
+#define BUF_READ_TIMEOUT	0xffffffff
+
+/******************************************************************************/
+/********************** Variables and User Defined Data Types *****************/
+/******************************************************************************/
+struct ad405x_support_desc {
+	/** Called when buffer ready to transfer. Write/read to/from dev */
+	int32_t	(*submit)(struct iio_device_data *dev);
+	/** Called before enabling buffer */
+	int32_t (*pre_enable)(void *dev, uint32_t mask);
+	/** Called after disabling buffer */
+	int32_t (*post_disable)(void *dev);
+	/** Called after a trigger signal has been received by iio */
+	int32_t (*trigger_handler)(struct iio_device_data *dev);
+};
+
+extern const struct ad405x_support_desc *support_desc[];
+
+#endif /* AD405X_SUPPORT_H_ */


### PR DESCRIPTION
Refactor the AD405x repository for better readability and support future upgrade/support if any. 

Since the AD405x is an umbrella term for multiple devices, the firmware is modified to support them.