### PR TITLE
projects:ad4170_iio: Ignore first sample during data capture

### DIFF
--- a/projects/ad4170_iio/app/app_config_stm32.c
+++ b/projects/ad4170_iio/app/app_config_stm32.c
@@ -281,7 +281,8 @@ void ad4170_spi_dma_rx_cplt_callback(DMA_HandleTypeDef* hdma)
 
 		ad4170_dma_buff_full = true;
 		iio_buf_current_idx = iio_buf_start_idx;
-		dma_buf_current_idx = dma_buf_start_idx;
+		dma_buf_current_idx = dma_buf_start_idx + (BYTES_PER_SAMPLE *
+				      num_of_active_channels);
 	} else {
 		memcpy((void*)iio_buf_current_idx, dma_buf_current_idx, rxdma_ndtr / 2);
 
@@ -326,7 +327,12 @@ void update_buff(uint32_t* local_buf, uint32_t* buf_start_addr)
 {
 #if (INTERFACE_MODE == SPI_DMA_MODE)
 	iio_buf_start_idx = (uint8_t*)buf_start_addr;
+#if (DATA_CAPTURE_MODE == BURST_DATA_CAPTURE)
+	dma_buf_start_idx = (uint8_t*)local_buf + (BYTES_PER_SAMPLE *
+			    num_of_active_channels);
+#else
 	dma_buf_start_idx = (uint8_t*)local_buf;
+#endif
 
 	iio_buf_current_idx = iio_buf_start_idx;
 	dma_buf_current_idx = dma_buf_start_idx;

--- a/projects/ad4170_iio/app/app_config_stm32.h
+++ b/projects/ad4170_iio/app/app_config_stm32.h
@@ -80,11 +80,11 @@
 /* Tx Trigger timer parameters */
 #define TX_TRIGGER_TIMER_ID         8 // Timer 8
 #define TX_TRIGGER_TIMER_HANDLE     htim8
-/* Tx trigger period considering a MAX SPI clock of 22.5MHz and 32 bit transfer */
-#define TX_TRIGGER_PERIOD           2250
-#define TX_TRIGGER_DUTY_RATIO       240
+/* Tx trigger period considering a MAX SPI clock of 20MHz and 32 bit transfer */
+#define TX_TRIGGER_PERIOD           700
+#define TX_TRIGGER_DUTY_RATIO       30
 #define TIMER_8_PRESCALER           0
-#define TIMER_8_CLK_DIVIDER         1
+#define TIMER_8_CLK_DIVIDER         2
 #define TIMER_CHANNEL_1				1
 #else
 /* The below configurations are specific to STM32H563ZIT6 MCU on NUCLEO-H563ZI Board. */


### PR DESCRIPTION
Ignore the first sample during data capture

Correct the parameters for tx trigger timer, as SPI wasn't operating at 500ksps data output rate during DMA capture