### PR TITLE
doc: Update the generic modules in Documentation

### DIFF
--- a/doc/sphinx/source/build/project_build.rst
+++ b/doc/sphinx/source/build/project_build.rst
@@ -155,7 +155,7 @@ Running a project
 
 Once the firmware build is successful and binary file is generated, copy the
 generated binary into USB drive hosted by your MCU board (e.g. USB drive hosted
-by SDP-K1 board on windows). This will flash the binary file into MCU present
+by the supported MCU board on windows). This will flash the binary file into MCU present
 on the controller board. Programming might vary based on the tools used for building
 a project. The 'Project Build' section above talks about this exception at the end
 of all build steps.

--- a/doc/sphinx/source/build/project_build_stm32.rst
+++ b/doc/sphinx/source/build/project_build_stm32.rst
@@ -14,6 +14,18 @@ for respective platform.
 
    .. collapsible:: STM32
 
+      * Clone Precision Converters Firmware repository with the --recursive flag:
+
+         .. code-block:: bash
+
+            git clone --recursive https://github.com/analogdevicesinc/precision-converters-firmware
+
+      * If however you've already cloned the repository without the --recursive flag, you may initialize all the submodules in an existing cloned repo with:
+
+      .. code-block:: bash
+
+            git submodule update --recursive --init
+
       .. collapsible:: For STM32 IDE based Build
 
             * Install `STM32CubeIDE <https://www.st.com/en/development-tools/stm32cubeide.html>`_
@@ -85,7 +97,7 @@ Running a project
 
 Once the firmware build is successful and binary file is generated, copy the
 generated binary into USB drive hosted by your MCU board (e.g. USB drive hosted
-by SDP-K1 board on windows). This will flash the binary file into MCU present
+by MCU board on windows). This will flash the binary file into MCU present
 on the controller board. Programming might vary based on the tools used for building
 a project. The 'Project Build' section above talks about this exception at the end
 of all build steps.

--- a/doc/sphinx/source/hardware/comm_interface.rst
+++ b/doc/sphinx/source/hardware/comm_interface.rst
@@ -6,11 +6,11 @@ Communication Interface
 
    For data transmission to IIO clients, IIO firmware applications uses *Virtual Serial*
    Or *UART* as primary communication links. Firmware by default uses the Virtual Serial
-   interface for higher speed data transmission as SDP-K1 MCU board supports
-   both Virtual Serial and UART interface. If you target a different MCU board that does not 
+   interface for SDP-K1 for higher speed data transmission as MCU board supports
+   both Virtual Serial and UART interface. The Nucleo-H563 supports only UART. If you target a different MCU board that does not 
    support Virtual Serial, just set UART as communication link in the firmware (app_config.h file).
 
-SDP-K1 is powered through USB connection from the computer. SDP-K1 MCU board 
+MCU board is powered through USB connection from the computer. It 
 acts as a serial device when connected to PC, which creates a serial ports to connect to IIO 
 client application running on PC. The serial port assigned to a device can be seen 
 through the device manager for windows-based OS as shown below:
@@ -36,6 +36,9 @@ firmware name which is currently running on MCU.
 SDP-K1 can support high speed Virtual Serial USB interface, so by default Virtual Serial
 is configured as default interface. The interface can be set to Physical (UART)
 serial port by defining macro **USE_PHY_COM_PORT** in the app_config.h file.
+
+Nucleo-H563 supports only UART interface, so by default Physical (UART) serial port
+is configured as default interface. 
 
 .. code-block:: C
 

--- a/doc/sphinx/source/iio_osc/data_capture_and_dmm.rst
+++ b/doc/sphinx/source/iio_osc/data_capture_and_dmm.rst
@@ -212,6 +212,9 @@ RAMs. For example, SDP-K1 MCU board has 16Mbytes of onboard SDRAM, which allows
 larger data buffer size in the firmware. By enabling SDRAM in the SDP-K1 targetted
 Mbed firmware (app_config.h file), the data buffer size can be increased to 16Mbytes.
 
+The Nucleo-H563 does not have an SDRAM supported. Hence, the data buffer size is limited to 
+the buffer provided in the firmware.
+
 .. code-block:: C
 
     /* Enable/Disable the use of SDRAM for ADC data capture buffer */

--- a/doc/sphinx/source/iio_osc/data_streaming.rst
+++ b/doc/sphinx/source/iio_osc/data_streaming.rst
@@ -120,7 +120,8 @@ required streaming samples number is more than the size of data buffer, IIO
 firmware returns negative error code to IIO client which then terminates the 
 data streaming request.
 
-Buffer size can be increased to larger value by making use of internal/external RAMs. 
+Buffer size can be increased to larger value by making use of internal/external RAMs, if supported by the
+MCU platform enabled by the project. 
 For example, SDP-K1 MCU board has 16Mbytes of onboard SDRAM, which allows larger data 
 buffer size in the firmware. By enabling SDRAM in the SDP-K1 
 (using the macro in app_config.h file), the data buffer size can be increased to 16Mbytes.


### PR DESCRIPTION
1) Update the generic modules in the documentation for instances where SDP-K1 has been mentioned as the only MCU

2) Add a step to recursive clone the precision-converters-firmware repo in the Steps for STM32 build