### PR TITLE
projects: ad7091r: Fix TX timer configuration

### DIFF
--- a/projects/ad7091r_iio/app/app_config.h
+++ b/projects/ad7091r_iio/app/app_config.h
@@ -138,7 +138,7 @@
 #define VIRTUAL_COM_SERIAL_NUM	(FIRMWARE_NAME "_" DEVICE_NAME "_" STR(PLATFORM_NAME))
 
 /* Enable/Disable the use of SDRAM for ADC data capture buffer */
-//#define USE_SDRAM		// Uncomment to use SDRAM for data buffer
+#define USE_SDRAM		// Uncomment to use SDRAM for data buffer
 
 /* PWM period and duty cycle */
 #define CONV_TRIGGER_PERIOD_NSEC(x) (((float)(1.0 / x) * 1000000) * 1000)

--- a/projects/ad7091r_iio/app/app_config_stm32.c
+++ b/projects/ad7091r_iio/app/app_config_stm32.c
@@ -124,7 +124,11 @@ struct stm32_pwm_init_param stm32_tx_trigger_extra_init_params = {
 	.timer_chn = TIMER_CHANNEL_1,
 	.complementary_channel = false,
 	.get_timer_clock = HAL_RCC_GetPCLK1Freq,
-	.clock_divider = TIMER_8_CLK_DIVIDER
+	.clock_divider = TIMER_8_CLK_DIVIDER,
+	.trigger_output = PWM_TRGO_ENABLE,
+	.dma_enable = true,
+	.repetitions = 1,
+	.onepulse_enable = true
 };
 
 /* STM32 Tx DMA channel extra init params */
@@ -234,9 +238,8 @@ void tim2_config(void)
  */
 void tim8_config(void)
 {
-	TIM8->RCR = BYTES_PER_SAMPLE - 1; // RCR value in one-pulse mode
-
-	TIM8->EGR = TIM_EGR_UG; // Generate update event
+	TIM8->SMCR |= (TIM_TS_ETRF | TIM_SLAVEMODE_TRIGGER |
+		       TIM_MASTERSLAVEMODE_ENABLE);
 
 	TIM8->DIER |=
 		TIM_DIER_CC1DE; // Generate DMA request after capture/compare event


### PR DESCRIPTION
Initialize tx trigger extra init params as required.

Update tim8_config function to act as a slave for
External trigger to generate DMA requests.

Enable SDRAM by default for data capture.