### PR TITLE
Ad4692 split mode

### DIFF
--- a/projects/ad4692_iio/STM32/sdp_k1/.extSettings
+++ b/projects/ad4692_iio/STM32/sdp_k1/.extSettings
@@ -2,7 +2,7 @@
 HeaderPath=../../app;../../../../libraries/no-OS/util;../../../../libraries/no-OS/include;../../../../libraries/no-OS/drivers/platform/stm32;../../../../libraries/no-OS/iio;../../../../libraries/no-OS/drivers/api;../../../../libraries/precision-converters-library/board_info/;../../../../libraries/precision-converters-library/common/;../../../../libraries/no-OS/drivers/eeprom/24xx32a/;../../../../libraries/no-OS/drivers/adc/ad4692/;../../../../libraries/precision-converters-library/sdp_k1_sdram/;../../../_common/;../../../_common/stm32/;
 
 [Groups]
-app/=../../app/main.c;../../app/ad4692_iio.c;../../app/ad4692_iio.h;../../app/ad4692_support.c;../../app/ad4692_support.h;../../app/app_config.h;../../app/app_config.c;../../app/app_config_stm32.c;../../app/app_config_stm32.h;../../app/stm32_gpio_irq_generated.c;../../app/ad4692_user_config.c;../../app/ad4692_user_config.h;../../app/eeprom_config.c;../../app/eeprom_config.h;../../app/version.h;../../app/ad4692_attrs.h;
+app/=../../app/main.c;../../app/ad4692_iio.c;../../app/ad4692_iio.h;../../app/ad4692_support.c;../../app/ad4692_support.h;../../app/ad4692_support_manual_mode.c;../../app/ad4692_support_cnv_clock_mode.c;../../app/ad4692_support_cnv_burst_mode.c;../../app/ad4692_support_spi_burst_mode.c;../../app/app_config.h;../../app/app_config.c;../../app/app_config_stm32.c;../../app/app_config_stm32.h;../../app/stm32_gpio_irq_generated.c;../../app/ad4692_user_config.c;../../app/ad4692_user_config.h;../../app/eeprom_config.c;../../app/eeprom_config.h;../../app/version.h;../../app/ad4692_attrs.h;
 
 app/_common/=../../../_common/adi_version.h;../../../_common/common_macros.h;
 

--- a/projects/ad4692_iio/app/ad4692_attrs.h
+++ b/projects/ad4692_iio/app/ad4692_attrs.h
@@ -2,7 +2,7 @@
 *   @file   ad4692_attrs.h
 *   @brief  Header file of ad4692 IIO attributes
 ********************************************************************************
-* Copyright (c) 2025 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 * This software is proprietary to Analog Devices, Inc. and its licensors.

--- a/projects/ad4692_iio/app/ad4692_iio.c
+++ b/projects/ad4692_iio/app/ad4692_iio.c
@@ -52,11 +52,12 @@ static void ad4692_get_tx_command(uint8_t* local_tx_data);
 /* ADC data buffer size */
 #if defined(USE_SDRAM)
 /* Offset the IIO buffer for 4 bytes to accommodate the 2-cycle command offset in manual mode */
-#define adc_data_buffer				SDRAM_START_ADDRESS + (N_CYCLE_OFFSET * BYTES_PER_SAMPLE)
-#define DATA_BUFFER_SIZE			SDRAM_SIZE_BYTES
+#define adc_data_buffer				SDRAM_START_ADDRESS
+#define DATA_BUFFER_SIZE			SDRAM_SIZE_BYTES - (N_CYCLE_OFFSET * BYTES_PER_SAMPLE)
 #else
 #define DATA_BUFFER_SIZE			(32768)		// 32kbytes
-static int8_t adc_data_buffer[DATA_BUFFER_SIZE];
+__attribute__((aligned(32))) static int8_t adc_data_buffer[DATA_BUFFER_SIZE +
+				 (N_CYCLE_OFFSET * BYTES_PER_SAMPLE)];
 #endif
 
 #define DATA_BUFFER_SIZE_CONT		(32768)		// 32kbytes
@@ -408,7 +409,8 @@ volatile uint32_t *buff_start_addr;
 
 /* Local buffer */
 #define MAX_LOCAL_BUF_SIZE	65536
-uint8_t local_buf[MAX_LOCAL_BUF_SIZE + (NO_OF_CHANNELS * N_CYCLE_OFFSET)];
+__attribute__((aligned(32))) uint8_t local_buf[MAX_LOCAL_BUF_SIZE +
+				   (NO_OF_CHANNELS * N_CYCLE_OFFSET)];
 
 /* Maximum value the DMA NDTR register can take */
 #define MAX_DMA_NDTR		(no_os_min(65532, (MAX_LOCAL_BUF_SIZE)))
@@ -2563,7 +2565,8 @@ int32_t iio_app_initialize(void)
 
 		/* Initialize the IIO interface */
 		iio_device_init_params[0].name = ACTIVE_DEVICE_NAME;
-		iio_device_init_params[0].raw_buf = (int8_t *)adc_data_buffer;
+		iio_device_init_params[0].raw_buf = (int8_t *)adc_data_buffer +
+						    (N_CYCLE_OFFSET * BYTES_PER_SAMPLE);
 		if (ad4692_data_capture_mode == CONTINUOUS) {
 			iio_device_init_params[0].raw_buf_len = DATA_BUFFER_SIZE_CONT;
 		} else {

--- a/projects/ad4692_iio/app/ad4692_iio.c
+++ b/projects/ad4692_iio/app/ad4692_iio.c
@@ -30,18 +30,6 @@
 #include "version.h"
 #include "ad4692_attrs.h"
 
-/******** Forward declaration of functions ********/
-
-static int ad4692_read_converted_data(struct ad4692_desc *desc,
-				      uint8_t chn,
-				      uint32_t *adc_data);
-
-static int ad4692_start_data_capture(struct ad4692_desc *desc);
-
-static int ad4692_stop_data_capture(struct ad4692_desc *desc);
-
-static void ad4692_get_tx_command(uint8_t* local_tx_data);
-
 /******************************************************************************/
 /************************ Macros/Constants ************************************/
 /******************************************************************************/
@@ -136,12 +124,6 @@ struct scan_type ad4692_iio_scan_type[NUM_OF_IIO_DEVICES][NO_OF_CHANNELS] = {
 #define ACC_COUNT_MIN_VAL	0
 #define ACC_COUNT_MAX_VAL	64
 
-/* Stop State mask */
-#define AD4692_ADC_MODE_STOP_STATE_MASK  NO_OS_BIT(5)
-
-/* Data Ready Stop state */
-#define AD4692_STOP_STATE_DATA_READYb   0x1
-
 /* ADC max count (full scale value) for unipolar inputs */
 #define ADC_MAX_COUNT_UNIPOLAR	(uint32_t) ((1 << ADC_RESOLUTION) - 1)
 
@@ -151,21 +133,12 @@ struct scan_type ad4692_iio_scan_type[NUM_OF_IIO_DEVICES][NO_OF_CHANNELS] = {
 /* AD4692 Offset */
 #define AD4692_OFFSET	0
 
-/* Converts pwm period in nanoseconds to sampling frequency in samples per second */
-#define PWM_PERIOD_TO_FREQUENCY(x)       (1000000000.0 / x)
-
 /* Maximum number of priorities supported in the FW */
 #define AD4692_MAX_PRIORITIES       2
 
 /* Supported resolutions- 16 and 24 bit */
 #define AD4692_RES_16		    16
 #define AD4692_RES_24		    24
-
-/* Number of bytes per transaction for accumulator data */
-#define AD4692_N_BYTES_CNV_CLOCK_24BIT	5
-
-/* Number of bytes per transaction for averaged data */
-#define AD4692_N_BYTES_CNV_CLOCK_16BIT	4
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -178,7 +151,7 @@ struct ad4692_desc *ad4692_dev = NULL;
 static struct iio_desc *ad4692_iio_desc;
 
 /* AD4692 IIO hw trigger descriptor */
-static struct iio_hw_trig *ad4692_hw_trig_desc;
+struct iio_hw_trig *ad4692_hw_trig_desc;
 
 /* AD4692 Board level attribute unique IDs */
 enum ad4692_board_attribute_ids {
@@ -238,34 +211,13 @@ static struct iio_channel
 };
 
 /* List of channels to be captured */
-static uint8_t ad4692_active_channels[NO_OF_CHANNELS];
-
-/* Channel ID during data capture */
-volatile uint8_t chan_id = 0;
+uint8_t ad4692_active_channels[NO_OF_CHANNELS];
 
 /* Number of channels enabled by the IIO Client */
 uint8_t num_of_active_channels = 0;
 
-/* Data buffer */
-uint8_t data_buff[BYTES_PER_SAMPLE] = { 0x0 };
-
-/* SPI message for manual mode capture */
-struct no_os_spi_msg ad4692_spi_msg_manual_mode = {
-	.cs_change = CS_CHANGE,
-	.tx_buff = data_buff,
-	.rx_buff = data_buff,
-	.bytes_number = BYTES_PER_SAMPLE
-};
-
 /* Flag to check end of conversion */
-static volatile bool ad4692_conversion_flag = false;
-
-/* Flag to indicate if size of the buffer is updated according to requested
- * number of samples for the multi-channel IIO buffer data alignment */
-static volatile bool buf_size_updated = false;
-
-/* Variable to store number of requested samples */
-static uint32_t nb_of_samples;
+volatile bool ad4692_conversion_flag = false;
 
 /* ADC Mode values */
 static const char *ad4692_adc_modes[] = {
@@ -338,20 +290,14 @@ static const char *readback_modes[] = {
 	"accumulator_data"
 };
 
-/* Enum of readback options */
-enum ad4692_readback_options {
-	AVERAGED_DATA,
-	ACCUMULATOR_DATA
-};
-
 /* Selected sequencer mode. Default is standard */
-static enum ad4692_sequencer_modes ad4692_sequencer_mode = STANDARD_SEQUENCER;
+enum ad4692_sequencer_modes ad4692_sequencer_mode = STANDARD_SEQUENCER;
 
 /* Selected interface mode. Default is SPI DMA */
 enum ad4692_interface_modes ad4692_interface_mode = SPI_DMA;
 
 /* Selected data capture mode. Default is Burst */
-enum ad4692_data_capture_modes ad4692_data_capture_mode = BURST;
+enum ad4692_data_capture_modes ad4692_data_capture_mode = BURST_DATA_CAPTURE;
 
 /* Selected readback option. Default is Averaged data */
 enum ad4692_readback_options ad4692_readback_option = AVERAGED_DATA;
@@ -360,19 +306,13 @@ enum ad4692_readback_options ad4692_readback_option = AVERAGED_DATA;
 static bool restart_iio_flag = false;
 
 /* Default oscillator frequency */
-static enum ad4692_int_osc_sel osc_freq_id = AD4692_OSC_1MHZ;
+enum ad4692_int_osc_sel ad4692_osc_freq_id = AD4692_OSC_1MHZ;
 
 /* Default channel sequencer length */
 static uint8_t seq_len = 0;
 
 /* Sampling frequency */
 uint32_t ad4692_sampling_frequency;
-
-/* Maximum Sampling frequency */
-uint32_t ad4692_sampling_frequency_max;
-
-/* EVB HW validation status */
-static bool hw_mezzanine_is_valid;
 
 /* Array to hold the channel priorities */
 uint8_t channel_priorities[NO_OF_CHANNELS] = { 0x0 };
@@ -386,39 +326,11 @@ uint8_t num_of_as_slots = 0;
 /* Data number of bytes */
 uint8_t n_data_bytes;
 
+/* Number of bytes per SPI transaction for non manual modes */
+uint8_t n_bytes_per_transaction = AD4692_N_BYTES_TXN_16BIT;
+
 /* STM32 SPI Init params */
 struct stm32_spi_init_param* spi_init_param;
-
-/* Global Pointer for IIO Device Data */
-volatile struct iio_device_data* iio_dev_data_g;
-
-/* Global variable for number of samples */
-uint32_t nb_of_samples_g;
-
-/* Global variable for data read from CB functions */
-uint32_t data_read;
-
-/* Flag to indicate if DMA has been configured for capture */
-volatile bool dma_config_updated = false;
-
-/* Flag for checking DMA buffer overflow */
-volatile bool ad4692_dma_buff_full = false;
-
-/* Variable to store start of buffer address */
-volatile uint32_t *buff_start_addr;
-
-/* Local buffer */
-#define MAX_LOCAL_BUF_SIZE	65536
-__attribute__((aligned(32))) uint8_t local_buf[MAX_LOCAL_BUF_SIZE +
-				   (NO_OF_CHANNELS * N_CYCLE_OFFSET)];
-
-/* Maximum value the DMA NDTR register can take */
-#define MAX_DMA_NDTR		(no_os_min(65532, (MAX_LOCAL_BUF_SIZE)))
-
-/* Variable to track the number of entries to the complete callback */
-uint32_t callback_count = 0;
-
-static bool dma_capture = false;
 
 /* IIO interface init parameters */
 struct iio_init_param  iio_init_params = {
@@ -428,126 +340,9 @@ struct iio_init_param  iio_init_params = {
 /* AD4692 IIO device descriptor */
 static struct iio_device *ad4692_iio_dev[NUM_OF_IIO_DEVICES];
 
-/* Accumulator data buffer */
-static uint8_t acc_data_buff[AD4692_N_BYTES_CNV_CLOCK_24BIT *
-							    AD4692_MAX_CHANNELS] = { 0x0 };
-
-/* Number of bytes per SPI transaction for non manual modes */
-static uint8_t n_bytes_per_transaction = AD4692_N_BYTES_CNV_CLOCK_16BIT;
-
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
-
-/**
- * @brief Set the sampling rate and get the updated value
- *	  supported by MCU platform
- * @return 0 in case of success, negative error code otherwise
- */
-int ad4692_update_sampling_frequency(uint32_t *sampling_rate)
-{
-	int ret;
-	uint64_t pwm_period_ns;
-	uint32_t period_ns_readback;
-	uint32_t prescaler;
-
-	if (*sampling_rate > ad4692_sampling_frequency_max) {
-		*sampling_rate = ad4692_sampling_frequency_max;
-	}
-
-	if (ad4692_interface_mode == SPI_DMA) {
-		ad4692_init_params.conv_param->period_ns = CONV_TRIGGER_PERIOD_NSEC(
-					*sampling_rate);
-		pwm_period_ns = CONV_TRIGGER_PERIOD_NSEC(*sampling_rate);
-
-		/* Compute prescaler to fit the period value within respective register */
-		ret = compute_optimal_prescaler(ad4692_dev->conv_desc->extra, pwm_period_ns,
-						&prescaler);
-		if (ret) {
-			return ret;
-		}
-
-		/* Set prescaler for timer */
-		ret = set_timer_prescaler(ad4692_dev->conv_desc, prescaler);
-		if (ret) {
-			return ret;
-		}
-
-		/* Initialize PWM with the updated rate */
-		ret = no_os_pwm_set_period(ad4692_dev->conv_desc,
-					   ad4692_init_params.conv_param->period_ns);
-		if (ret) {
-			return ret;
-		}
-	} else { // SPI_INTR
-
-		if (ad4692_init_params.mode == AD4692_SPI_BURST) {
-			pwm_period_ns = CONV_TRIGGER_PERIOD_NSEC(*sampling_rate);
-
-			/* Compute prescaler to fit the period value within respective register */
-			ret = compute_optimal_prescaler(spi_burst_pwm_desc->extra, pwm_period_ns,
-							&prescaler);
-			if (ret) {
-				return ret;
-			}
-
-			/* Set prescaler for timer */
-			ret = set_timer_prescaler(spi_burst_pwm_desc, prescaler);
-			if (ret) {
-				return ret;
-			}
-
-			ret = no_os_pwm_set_period(spi_burst_pwm_desc, pwm_period_ns);
-			if (ret) {
-				return ret;
-			}
-		} else {
-			pwm_period_ns = CONV_TRIGGER_PERIOD_NSEC(*sampling_rate);
-
-			/* Compute prescaler to fit the period value within respective register */
-			ret = compute_optimal_prescaler(ad4692_dev->conv_desc->extra, pwm_period_ns,
-							&prescaler);
-			if (ret) {
-				return ret;
-			}
-
-			/* Set prescaler for timer */
-			ret = set_timer_prescaler(ad4692_dev->conv_desc, prescaler);
-			if (ret) {
-				return ret;
-			}
-
-			ret = no_os_pwm_set_period(ad4692_dev->conv_desc, pwm_period_ns);
-			if (ret) {
-				return ret;
-			}
-
-			ret = no_os_pwm_set_duty_cycle(ad4692_dev->conv_desc,
-						       CONV_TRIGGER_DUTY_CYCLE_NSEC(pwm_period_ns));
-			if (ret) {
-				return ret;
-			}
-		}
-	}
-
-	if (ad4692_init_params.mode == AD4692_SPI_BURST) {
-		/* Get the actual period of the PWM */
-		ret = no_os_pwm_get_period(spi_burst_pwm_desc, &period_ns_readback);
-		if (ret) {
-			return ret;
-		}
-	} else {
-		/* Get the actual period of the PWM */
-		ret = no_os_pwm_get_period(ad4692_dev->conv_desc, &period_ns_readback);
-		if (ret) {
-			return ret;
-		}
-	}
-
-	ad4692_sampling_frequency = PWM_PERIOD_TO_FREQUENCY(period_ns_readback);
-
-	return 0;
-}
 
 /*!
  * @brief	Getter/Setter for the raw, offset and scale attribute value
@@ -565,44 +360,24 @@ int ad4692_iio_attr_get(void *device,
 			intptr_t priv)
 {
 	int ret;
-	uint32_t data_read;
+	uint32_t adc_data;
+	uint32_t reg_val;
 	uint8_t ch;
 
 	switch (priv) {
 	case ADC_RAW_ATTR_ID:
-		dma_capture = false;
-
-		/* Check if device is already in manual mode, exit from the same */
-		if (ad4692_init_params.mode == AD4692_MANUAL_MODE) {
-			ret = ad4692_stop_data_capture(ad4692_dev);
-			if (ret) {
-				return ret;
-			}
-		}
-
 		channel_mask = NO_OS_BIT(channel->ch_num);
 		ad4692_active_channels[0] = channel->ch_num;
 		num_of_active_channels = 1;
 
-		/* Start Data capture */
-		ret = ad4692_start_data_capture(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-
 		/* Read the ADC Sample */
-		ret = ad4692_read_converted_data(ad4692_dev, channel->ch_num, &data_read);
+		ret = ad4692_data_transfer_read_converted_data(ad4692_dev, channel->ch_num,
+				&adc_data);
 		if (ret) {
 			return ret;
 		}
 
-		/* Stop Data capture */
-		ret = ad4692_stop_data_capture(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-
-		return sprintf(buf, "%ld", data_read);
+		return sprintf(buf, "%lu", adc_data);
 
 	case ADC_SCALE_ATTR_ID:
 
@@ -612,7 +387,7 @@ int ad4692_iio_attr_get(void *device,
 		return sprintf(buf, "%d", AD4692_OFFSET);
 
 	case ADC_SAMPLING_FREQUENCY_ATTR_ID:
-		return sprintf(buf, "%ld", ad4692_sampling_frequency);
+		return sprintf(buf, "%lu", ad4692_sampling_frequency);
 
 	case ADC_MODE_ATTR_ID:
 		return sprintf(buf, "%s", ad4692_adc_modes[ad4692_init_params.mode]);
@@ -630,27 +405,23 @@ int ad4692_iio_attr_get(void *device,
 		return sprintf(buf, "%s", readback_modes[ad4692_readback_option]);
 
 	case ACC_COUNT_ATTR_ID:
-		/* In Standard Sequencer Mode, the ACC_DEPTH_IN0 register sets
-		 * the accumulator depth for all 16 channels. For Advanced Sequencer Mode,
-		 * each channel's depth settings are independently programmed via the
-		 * ACC_DEPTH_IN0, ACC_DEPTH_IN1, ... , ACC_DEPTH_IN15 registers */
 		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
 			ch = 0;
 		} else {
 			ch = channel->ch_num;
 		}
 
-		return sprintf(buf, "%d", ad4692_acc_count[ch]);
+		return sprintf(buf, "%u", ad4692_acc_count[ch]);
 
 	case OSC_FREQUENCY_ATTR_ID:
-		return sprintf(buf, "%s", ad4692_osc_frequencies[osc_freq_id]);
+		return sprintf(buf, "%s", ad4692_osc_frequencies[ad4692_osc_freq_id]);
 
 	case SEQUENCE_LENGTH_ATTR_ID:
-		ret = ad4692_reg_read(ad4692_dev, AD4692_SEQUENCER_CONTROL_REG, &data_read);
+		ret = ad4692_reg_read(ad4692_dev, AD4692_SEQUENCER_CONTROL_REG, &reg_val);
 		if (ret) {
 			return ret;
 		}
-		seq_len = no_os_field_get(AD4692_ADV_SEQ_MODE_MASK, data_read);
+		seq_len = no_os_field_get(AD4692_ADV_SEQ_MODE_MASK, reg_val);
 
 		return sprintf(buf, "%d", seq_len);
 
@@ -700,8 +471,6 @@ int ad4692_iio_attr_set(void *device,
 			return -EINVAL;
 		}
 
-		/* Update the mode in the init params
-		 * to include the updated mode during IIO re-initialization */
 		ad4692_init_params.mode = id;
 
 		break;
@@ -735,7 +504,7 @@ int ad4692_iio_attr_set(void *device,
 		break;
 
 	case DATA_CAPTURE_MODE_ATTR_ID:
-		for (id = CONTINUOUS; id <= BURST; id++) {
+		for (id = CONTINUOUS_DATA_CAPTURE; id <= BURST_DATA_CAPTURE; id++) {
 			if (!strcmp(buf, data_capture_modes[id])) {
 				ad4692_data_capture_mode = id;
 				break;
@@ -749,10 +518,6 @@ int ad4692_iio_attr_set(void *device,
 		break;
 
 	case ACC_COUNT_ATTR_ID:
-		/* In Standard Sequencer Mode, the ACC_DEPTH_IN0 register sets
-		 * the accumulator depth for all 16 channels. For Advanced Sequencer Mode,
-		 * each channel's depth settings are independently programmed via the
-		 * ACC_DEPTH_IN0, ACC_DEPTH_IN1, ... , ACC_DEPTH_IN15 registers */
 		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
 			ch = 0;
 		} else {
@@ -763,7 +528,6 @@ int ad4692_iio_attr_set(void *device,
 			return -EINVAL;
 		}
 
-		/* Set the channel to the configured accumulator count */
 		ret = ad4692_reg_write(ad4692_dev, AD4692_ACC_COUNT_LIMIT_REG(ch),
 				       no_os_str_to_uint32(buf));
 		if (ret) {
@@ -781,17 +545,15 @@ int ad4692_iio_attr_set(void *device,
 			}
 		}
 
-		/* Configure the selected oscillator frequency */
 		ret = ad4692_set_osc(ad4692_dev, id);
 		if (ret) {
 			return ret;
 		}
-		osc_freq_id = id;
+		ad4692_osc_freq_id = id;
 
 		break;
 
 	case SEQUENCE_LENGTH_ATTR_ID:
-		/* Channel sequence length is a read-only attribute */
 		break;
 
 	case READBACK_OPTION_ATTR_ID:
@@ -810,7 +572,7 @@ int ad4692_iio_attr_set(void *device,
 
 	case ADC_SAMPLING_FREQUENCY_ATTR_ID:
 		s_rate = no_os_str_to_uint32(buf);
-		ret = ad4692_update_sampling_frequency(&s_rate);
+		ret = ad4692_data_transfer_update_freq(&s_rate);
 		if (ret) {
 			return ret;
 		}
@@ -832,7 +594,6 @@ int ad4692_iio_attr_set(void *device,
 		break;
 
 	case RESTART_IIO_ATTR_ID:
-		/* Set flag to true */
 		restart_iio_flag = true;
 		break;
 
@@ -878,7 +639,6 @@ int ad4692_iio_attr_available_get(void *device,
 		}
 
 	case INTERFACE_MODE_ATTR_ID:
-		/* SPI DMA mode is supported only for manual mode */
 		if (ad4692_init_params.mode == AD4692_MANUAL_MODE) {
 			return sprintf(buf, "%s %s",
 				       interface_modes[0],
@@ -952,1136 +712,13 @@ int ad4692_iio_attr_available_set(void *device,
 }
 
 /*!
- * @brief Read ADC converted data
- * @param desc[in, out]- AD4692 device descriptor
- * @param chn[in] - Channel ID (number)
- * @param adc_data[out] - ADC converted data
- * @return len in case of success, negative error code otherwise
- */
-static int ad4692_read_converted_data(struct ad4692_desc *desc,
-				      uint8_t chn,
-				      uint32_t *adc_data)
-{
-	int ret;
-	uint8_t eoc_status;
-	uint32_t timeout = BUF_READ_TIMEOUT;
-
-	switch (ad4692_init_params.mode) {
-	case AD4692_MANUAL_MODE:
-		data_buff[0] = AD4692_IN_COMMAND(chn);
-		data_buff[1] = 0x0;
-		eoc_status = NO_OS_GPIO_HIGH;
-
-		ret = no_os_gpio_direction_input(desc->gpio0_desc);
-		if (ret) {
-			return ret;
-		}
-
-		/* Toggle CNV as a GPIO */
-		ret = ad4692_toggle_cnv(cnv_gpio_desc);
-		if (ret) {
-			return ret;
-		}
-
-		/* Poll for BSY Low */
-		do {
-			ret = no_os_gpio_get_value(desc->gpio0_desc, &eoc_status);
-			if (ret) {
-				return ret;
-			}
-		} while ((eoc_status != NO_OS_GPIO_LOW) && (timeout-- > 0));
-
-		if (timeout == 0) {
-			return -ETIMEDOUT;
-		}
-
-		ret = no_os_spi_transfer(ad4692_dev->comm_desc, &ad4692_spi_msg_manual_mode, 1);
-		if (ret) {
-			return ret;
-		}
-
-		*adc_data = no_os_get_unaligned_be16(ad4692_spi_msg_manual_mode.rx_buff);
-
-		break;
-
-	case AD4692_CNV_CLOCK:
-	case AD4692_CNV_BURST:
-	case AD4692_SPI_BURST:
-
-		/* Enable CNV PWM */
-		ret = no_os_pwm_enable(desc->conv_desc);
-		if (ret) {
-			return ret;
-		}
-
-		if (ad4692_init_params.mode == AD4692_SPI_BURST) {
-			/* Write to Convert Start register to trigger the next burst of conversion */
-			ret = ad4692_reg_write(ad4692_dev,
-					       AD4692_OSC_EN_REG,
-					       AD4692_CONV_START_MASK);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		eoc_status = NO_OS_GPIO_HIGH;
-
-		/* Poll for DATA_READYb Low */
-		do {
-			ret = no_os_gpio_get_value(desc->gpio0_desc, &eoc_status);
-			if (ret) {
-				return ret;
-			}
-		} while (eoc_status != NO_OS_GPIO_LOW && timeout-- > 0);
-
-		if (timeout == 0) {
-			return -ETIMEDOUT;
-		}
-
-		ret = ad4692_reg_read(ad4692_dev,
-				      AD4692_AVG_IN_REG(chn),
-				      adc_data);
-		if (ret) {
-			return ret;
-		}
-		*adc_data = no_os_get_unaligned_be16((uint8_t *)adc_data);
-
-		/* Reset the state of accumulator to start a new burst of conversion */
-		ret = ad4692_reg_write(ad4692_dev,
-				       AD4692_STATE_RESET_REG,
-				       AD4692_STATE_RESET_ALL);
-		if (ret) {
-			return ret;
-		}
-
-		/* Disable CNV PWM */
-		ret = no_os_pwm_disable(desc->conv_desc);
-		if (ret) {
-			return ret;
-		}
-
-		break;
-
-	default:
-
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-/**
- * @brief Initialize device for data capture
- * @param desc[in, out] - AD4692 Device Descriptor
- * @return 0 in case of success, negative error code otherwise.
- */
-int ad4692_start_data_capture(struct ad4692_desc *desc)
-{
-	int ret;
-	uint8_t toggle_n;
-	uint8_t ch_id;
-	struct no_os_spi_msg ad4692_spi_msg = {
-		.cs_change = CS_CHANGE,
-		.tx_buff = data_buff,
-		.rx_buff = data_buff,
-		.bytes_number = BYTES_PER_SAMPLE
-	};
-
-	if (!desc) {
-		return -EINVAL;
-	}
-
-	switch (ad4692_init_params.mode) {
-	case AD4692_MANUAL_MODE:
-		ret = init_gpio();
-		if (ret) {
-			return ret;
-		}
-
-		/* Configure GPIO0 as BUSY */
-		ret = ad4692_gpio_set(desc,
-				      AD4692_GPIO0,
-				      AD4692_GPIO_OUTPUT_ADC_BUSY);
-		if (ret) {
-			return ret;
-		}
-
-		/* Enter Manual Mode */
-		ret = ad4692_reg_write(desc,
-				       AD4692_DEVICE_SETUP_REG,
-				       AD4692_DEVICE_MANUAL);
-		if (ret) {
-			return ret;
-		}
-
-		if (!dma_capture) {
-			/* Toggle CNV at a gap of 5us */
-			for (toggle_n = 0; toggle_n < AD4692_N_CNV_TOGGLES; toggle_n++) {
-				no_os_udelay(5);
-				ret = ad4692_toggle_cnv(cnv_gpio_desc);
-				if (ret) {
-					return ret;
-				}
-
-				/* Register the channel ID */
-				data_buff[0] = AD4692_IN_COMMAND(ad4692_active_channels[chan_id]);
-				data_buff[1] = 0x0;
-
-				/* Since manual mode operates with an offset of 2 CNV pulses,
-				 * Iterate through the first two enabled channels if more
-				 * than one channel is enabled. Else, register the only enabled channel- twice */
-				if (num_of_active_channels > 1) {
-					chan_id++;
-				}
-
-				ret = no_os_spi_transfer(desc->comm_desc, &ad4692_spi_msg, 1);
-				if (ret) {
-					return ret;
-				}
-			}
-		}
-
-		break;
-
-	case AD4692_CNV_CLOCK:
-		/* Reset manual mode bit */
-		ad4692_reg_update(desc,
-				  AD4692_DEVICE_SETUP_REG,
-				  AD4692_MANUAL_MODE_MASK,
-				  AD4692_EXIT_MANUAL_MODE);
-
-		/* Enter CNV Clock Mode */
-		ret = ad4692_reg_update(desc,
-					AD4692_ADC_SETUP_REG,
-					AD4692_MODE_MASK,
-					AD4692_CNV_CLOCK);
-		if (ret) {
-			return ret;
-		}
-
-		/* Configure GPIO0 as DATA_READYb */
-		ret = ad4692_reg_update(desc,
-					AD4692_GPIO_MODE1_REG,
-					AD4692_GPIO0_MASK,
-					AD4692_GPIO_OUTPUT_DATA_READYb);
-
-		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-			/* Enable the desired channels */
-			ret = ad4692_std_seq_ch(desc, channel_mask, true, 0);
-			if (ret) {
-				return ret;
-			}
-
-			/* Configure accumulator mask */
-			ret = ad4692_configure_acc_mask(channel_mask, ad4692_sequencer_mode,
-							channel_priorities);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		/* Configure the accumulator count limit */
-		for (ch_id = 0; ch_id < num_of_active_channels; ch_id++) {
-			ret = ad4692_reg_write(desc,
-					       AD4692_ACC_COUNT_LIMIT_REG(ad4692_active_channels[ch_id]),
-					       ad4692_acc_count[ad4692_active_channels[ch_id]]);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		break;
-
-	case AD4692_CNV_BURST:
-		/* Reset manual mode bit */
-		ret = ad4692_reg_update(desc,
-					AD4692_DEVICE_SETUP_REG,
-					AD4692_MANUAL_MODE_MASK,
-					AD4692_EXIT_MANUAL_MODE);
-		if (ret) {
-			return ret;
-		}
-
-		/* Reset the state of the accumulator */
-		ret = ad4692_reg_write(desc,
-				       AD4692_STATE_RESET_REG,
-				       AD4692_STATE_RESET_ALL);
-		if (ret) {
-			return ret;
-		}
-
-		/* Set all channels to the configured accumulator count */
-		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
-			ret = ad4692_reg_write(ad4692_dev, AD4692_ACC_COUNT_LIMIT_REG(ch_id),
-					       ad4692_acc_count[ch_id]);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		/* Configure GPIO0 as DATA_READYb */
-		ret = ad4692_reg_update(desc,
-					AD4692_GPIO_MODE1_REG,
-					AD4692_GPIO0_MASK,
-					AD4692_GPIO_OUTPUT_DATA_READYb);
-		if (ret) {
-			return ret;
-		}
-
-		/* Configure DATA_READYb as the stop state trigger */
-		ret = ad4692_reg_update(desc,
-					AD4692_ADC_SETUP_REG,
-					AD4692_ADC_MODE_STOP_STATE_MASK,
-					no_os_field_prep(AD4692_ADC_MODE_STOP_STATE_MASK,
-							AD4692_STOP_STATE_DATA_READYb));
-		if (ret) {
-			return ret;
-		}
-
-		/* Enable the desired channels.*/
-		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-			ret = ad4692_std_seq_ch(desc, channel_mask, true, 0);
-			if (ret) {
-				return ret;
-			}
-
-			/* Configure accumulator mask */
-			ret = ad4692_configure_acc_mask(channel_mask, ad4692_sequencer_mode,
-							channel_priorities);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		/* Enter CNV Burst Mode */
-		ret = ad4692_reg_update(desc,
-					AD4692_ADC_SETUP_REG,
-					AD4692_MODE_MASK,
-					AD4692_CNV_BURST);
-		if (ret) {
-			return ret;
-		}
-
-		break;
-
-	case AD4692_SPI_BURST:
-		/* Reset manual mode bit */
-		ret = ad4692_reg_update(desc,
-					AD4692_DEVICE_SETUP_REG,
-					AD4692_MANUAL_MODE_MASK,
-					AD4692_EXIT_MANUAL_MODE);
-		if (ret) {
-			return ret;
-		}
-
-		/* Configure GPIO0 as DATA_READYb */
-		ret = ad4692_reg_update(desc,
-					AD4692_GPIO_MODE1_REG,
-					AD4692_GPIO0_MASK,
-					AD4692_GPIO_OUTPUT_DATA_READYb);
-		if (ret) {
-			return ret;
-		}
-
-		/* Configure DATA_READYb as the stop state trigger */
-		ret = ad4692_reg_update(desc,
-					AD4692_ADC_SETUP_REG,
-					AD4692_ADC_MODE_STOP_STATE_MASK,
-					no_os_field_prep(AD4692_ADC_MODE_STOP_STATE_MASK,
-							AD4692_STOP_STATE_DATA_READYb));
-		if (ret) {
-			return ret;
-		}
-
-		/* Set all channels to the configured accumulator count */
-		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
-			ret = ad4692_reg_write(ad4692_dev, AD4692_ACC_COUNT_LIMIT_REG(ch_id),
-					       ad4692_acc_count[ch_id]);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-			ret = ad4692_std_seq_ch(desc, channel_mask, true, 0);
-			if (ret) {
-				return ret;
-			}
-
-			/* Configure accumulator mask */
-			ret = ad4692_configure_acc_mask(channel_mask, ad4692_sequencer_mode,
-							channel_priorities);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		/* Configure the oscillator frequency */
-		ret = ad4692_set_osc(ad4692_dev, osc_freq_id);
-		if (ret) {
-			return ret;
-		}
-
-		/* Enter SPI Burst Mode */
-		ret = ad4692_reg_update(desc,
-					AD4692_ADC_SETUP_REG,
-					AD4692_MODE_MASK,
-					AD4692_SPI_BURST);
-		if (ret) {
-			return ret;
-		}
-
-		/* Write to Convert Start register */
-		ret = ad4692_reg_write(desc,
-				       AD4692_OSC_EN_REG,
-				       AD4692_CONV_START_MASK);
-		if (ret) {
-			return ret;
-		}
-
-		break;
-
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-/**
- * @brief Exit device from data capture
- * @param desc[in, out] - AD4692 Device Descriptor
- * @return 0 in case of success, negative error code otherwise.
- */
-int ad4692_stop_data_capture(struct ad4692_desc *desc)
-{
-	int ret;
-
-	if (!desc) {
-		return -EINVAL;
-	}
-
-	switch (ad4692_init_params.mode) {
-	case AD4692_MANUAL_MODE:
-		/* Initialize CNV as a GPIO */
-		ret = init_gpio();
-		if (ret) {
-			return ret;
-		}
-
-		ret = ad4692_exit_manual_mode(desc, cnv_gpio_desc);
-		if (ret) {
-			return ret;
-		}
-
-		ret = no_os_gpio_remove(cnv_gpio_desc);
-		if (ret) {
-			return ret;
-		}
-		cnv_gpio_desc = NULL;
-
-		desc->mode = AD4692_CNV_CLOCK;
-
-		break;
-
-	case AD4692_CNV_CLOCK:
-	case AD4692_CNV_BURST:
-	case AD4692_SPI_BURST:
-		break;
-
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-/**
- * @brief Prepare for ADC data capture (transfer from device to memory)
- * @param dev_instance[in] - IIO device instance
- * @param chn_mask[in] - Channels select mask
- * @return 0 in case of success, negative error code otherwise
- */
-static int32_t ad4692_iio_prepare_transfer(void* dev_instance, uint32_t ch_mask)
-{
-	int32_t ret;
-	uint8_t ch_id;
-	uint8_t index = 0;
-	uint32_t mask = 0x1;
-	num_of_active_channels = 0;
-	chan_id = 0;
-	memset(ad4692_active_channels, 0, NO_OF_CHANNELS);
-
-	if (!dev_instance) {
-		return -EINVAL;
-	}
-
-	if (ad4692_interface_mode == SPI_DMA) {
-		dma_capture = true;
-	}
-
-	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-		/* Updates the count of total number of active channels */
-		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
-			if (mask & ch_mask) {
-				ad4692_active_channels[index++] = ch_id;
-				num_of_active_channels++;
-			}
-			mask <<= 1;
-		}
-		channel_mask = ch_mask;
-	} else {
-		/* Updates the count of total number of active channels in advanced sequencer mode */
-		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
-			if (channel_priorities[ch_id] != 0) {
-				ad4692_active_channels[index++] = ch_id;
-				num_of_active_channels++;
-				mask |= (1 << ch_id);
-			}
-		}
-		channel_mask = mask;
-	}
-
-	if ((ad4692_data_capture_mode == CONTINUOUS)
-	    || (ad4692_interface_mode == SPI_DMA)) {
-		/* Start ADC Data capture */
-		ret = ad4692_start_data_capture(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-	}
-	if (ad4692_interface_mode == SPI_INTR) {
-		ad4692_init_params.conv_param->period_ns = CONV_TRIGGER_PERIOD_NSEC(
-					ad4692_sampling_frequency);
-		ad4692_init_params.conv_param->duty_cycle_ns = CNV_ON_TIME;
-		pwm_spi_burst_init.period_ns = CONV_TRIGGER_PERIOD_NSEC(
-						       ad4692_sampling_frequency);
-
-		ret = init_pwm();
-		if (ret) {
-			return ret;
-		}
-
-		if (ad4692_data_capture_mode == CONTINUOUS) {
-#if	(ACTIVE_PLATFORM == STM32_PLATFORM)
-			/* Clear any pending interrupts occured from a spurious falling edge of
-			 * GPIO pin during toggling the CNV as a GPIO in the ad4692_start_data_capture()
-			 * Note: EOC for SPI Burst is triggered in the ad4692_start_data_capture() when
-			 * AD4692_CONV_START_REG is configured. Hence, no clearing of pending interrupt
-			 * needed for SPI Burst */
-			if (ad4692_init_params.mode != AD4692_SPI_BURST) {
-				ret = no_os_irq_clear_pending(trigger_irq_desc, TRIGGER_INT_ID);
-				if (ret) {
-					return ret;
-				}
-			}
-#endif // ACTIVE_PLATFORM
-			ret = iio_trig_enable(ad4692_hw_trig_desc);
-			if (ret) {
-				return ret;
-			}
-
-			/* Configure CNV PWM and start */
-			ret = ad4692_config_and_start_pwm(ad4692_dev);
-			if (ret) {
-				return ret;
-			}
-		}
-	} else { // SPI DMA
-
-		/* Pull the SPI CS line low to enable the data on SDO.*/
-		ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_LOW);
-		if (ret) {
-			return ret;
-		}
-
-		/* Initialize Tx Trigger Timer */
-		ret = tx_trigger_init();
-		if (ret) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
-/**
- * @brief	Perform tasks before end of current data transfer
- * @param	dev[in] - IIO device instance
- * @return	0 in case of success, negative error code otherwise
- */
-static int32_t ad4692_iio_end_transfer(void *dev)
-{
-	int32_t ret;
-
-	if (!dev) {
-		return -EINVAL;
-	}
-
-	if (ad4692_interface_mode == SPI_INTR) {
-		if (ad4692_data_capture_mode == CONTINUOUS) {
-			/* Stop timer */
-			ad4692_stop_timer();
-
-			/* Disable triggers */
-			ret = iio_trig_disable(ad4692_hw_trig_desc);
-			if (ret) {
-				return ret;
-			}
-		}
-	} else { // SPI_DMA
-		/* Stop timers */
-		ad4692_stop_timer();
-
-		stm32_abort_dma_transfer();
-
-		/* Pull the SPI CS line back high to enable reg Access */
-		ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_HIGH);
-		if (ret) {
-			return ret;
-		}
-
-		/* De initialize the Tx Trigger PWM */
-		ret = no_os_pwm_disable(tx_trigger_desc);
-		if (ret) {
-			return ret;
-		}
-
-		dma_config_updated = false;
-	}
-	/* Stop ADC Data capture */
-	ret = ad4692_stop_data_capture(ad4692_dev);
-	if (ret) {
-		return ret;
-	}
-
-	buf_size_updated = false;
-
-	return 0;
-}
-
-/**
- * @brief Push data into IIO buffer when trigger handler IRQ is invoked
- * @param iio_dev_data[in] - IIO device data instance
- * @return 0 in case of success or negative value otherwise
- */
-int32_t ad4692_trigger_handler(struct iio_device_data *iio_dev_data)
-{
-	int ret;
-	uint32_t data_read = 0;
-	uint8_t eoc_status;
-	uint32_t timeout = BUF_READ_TIMEOUT;
-	uint8_t id = 0;
-	uint8_t bytes_offset = 2; // Offset to start reading the Rx word from SPI Data
-
-	if (ad4692_init_params.mode == AD4692_MANUAL_MODE) {
-		/* Reset the channel ID back to the first enabled channel in ascending order */
-		if (chan_id >= num_of_active_channels) {
-			chan_id = 0;
-		}
-
-		data_buff[0] = AD4692_IN_COMMAND(ad4692_active_channels[chan_id++]);
-		data_buff[1] = 0x0;
-
-		ret = no_os_spi_transfer(ad4692_dev->comm_desc, &ad4692_spi_msg_manual_mode, 1);
-		if (ret) {
-			return ret;
-		}
-
-		ret = no_os_cb_write(iio_dev_data->buffer->buf,
-				     ad4692_spi_msg_manual_mode.rx_buff,
-				     n_data_bytes);
-		if (ret) {
-			return ret;
-		}
-	} else {
-		/* Populate the Tx command */
-		ad4692_get_tx_command(acc_data_buff);
-
-		if (ad4692_init_params.mode == AD4692_SPI_BURST) {
-			/* Write to Convert Start register to trigger the next burst of conversion */
-			ret = ad4692_reg_write(ad4692_dev,
-					       AD4692_OSC_EN_REG,
-					       AD4692_CONV_START_MASK);
-			if (ret) {
-				return ret;
-			}
-			/* Poll for BSY Low */
-			do {
-				ret = no_os_gpio_get_value(ad4692_dev->gpio0_desc, &eoc_status);
-				if (ret) {
-					return ret;
-				}
-			} while ((eoc_status != NO_OS_GPIO_LOW) && (timeout-- > 0));
-
-			if (timeout == 0) {
-				return -ETIMEDOUT;
-			}
-		}
-
-		/* Pull CS low, read the data of all channels and Pull back CS High */
-		ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_LOW);
-		if (ret) {
-			return ret;
-		}
-
-		ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, &acc_data_buff[0],
-					       num_of_active_channels * n_bytes_per_transaction);
-		if (ret) {
-			return ret;
-		}
-
-		ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_HIGH);
-		if (ret) {
-			return ret;
-		}
-
-		for (chan_id = 0; chan_id < num_of_active_channels; chan_id++) {
-			id = (chan_id * n_bytes_per_transaction) + bytes_offset;
-			if (ad4692_readback_option == ACCUMULATOR_DATA) {
-				data_read = no_os_get_unaligned_be24(&acc_data_buff[id]);
-			} else {
-				data_read = no_os_get_unaligned_be16(&acc_data_buff[id]);
-			}
-
-			ret = no_os_cb_write(iio_dev_data->buffer->buf,
-					     &data_read,
-					     n_data_bytes);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		/* Reset the state of accumulator to start a new burst of conversion */
-		ret = ad4692_reg_write(ad4692_dev,
-				       AD4692_STATE_RESET_REG,
-				       AD4692_STATE_RESET_ALL);
-		if (ret) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
-/*!
  * @brief Interrupt Service Routine to monitor end of conversion event.
  * @param ctx[in] - Callback context (unused)
  * @return none
- * @note Callback registered for the the DRDY interrupt to indicate
- * end of conversion in case of burst data capturing with SPI operation.
  */
 void ad4692_data_capture_callback(void *ctx)
 {
 	ad4692_conversion_flag = true;
-}
-
-/**
- * @brief  Get the Tx buffer respective to the enabled channels
- * @param local_tx_data[out] Tx buffer
- * @return None
- */
-void ad4692_get_tx_command(uint8_t* local_tx_data)
-{
-	uint8_t ch_id;
-	uint8_t index;
-
-
-	if (ad4692_init_params.mode == AD4692_MANUAL_MODE) {
-		for (ch_id = 0; ch_id < num_of_active_channels; ch_id++) {
-			index = ad4692_active_channels[ch_id];
-			local_tx_data[ch_id * BYTES_PER_SAMPLE] = AD4692_IN_COMMAND(index);
-			local_tx_data[(ch_id * BYTES_PER_SAMPLE) + 1] = 0;
-		}
-	} else {
-		index = 0;
-		for (ch_id = 0; ch_id < num_of_active_channels; ch_id++) {
-			if (ad4692_readback_option == ACCUMULATOR_DATA) {
-				acc_data_buff[index++] = AD4692_RW_ADDR_MASK | AD4692_MSB_MASK(
-								 AD4692_ACC_IN_REG(
-										 ad4692_active_channels[ch_id]));
-				acc_data_buff[index++] = AD4692_LSB_MASK(AD4692_ACC_IN_REG(
-								 ad4692_active_channels[ch_id]));
-				acc_data_buff[index++] = 0x0;
-				acc_data_buff[index++] = 0x0;
-				acc_data_buff[index++] = 0x0;
-			} else {
-				acc_data_buff[index++] = AD4692_RW_ADDR_MASK | AD4692_MSB_MASK(
-								 AD4692_AVG_IN_REG(
-										 ad4692_active_channels[ch_id]));
-				acc_data_buff[index++] = AD4692_LSB_MASK(AD4692_AVG_IN_REG(
-								 ad4692_active_channels[ch_id]));
-				acc_data_buff[index++] = 0x0;
-				acc_data_buff[index++] = 0x0;
-			}
-		}
-	}
-}
-
-/**
- * @brief Read data in burst mode via SPI DMA
- * @param nb_of_samples[in] - Number of samples requested by IIO
- * @param iio_dev_data[in] - IIO Device data instance
- * @return 0 in case of success or negative value otherwise
- */
-static int32_t ad4692_read_data_spi_dma(uint32_t nb_of_samples,
-					struct iio_device_data* iio_dev_data)
-{
-	int ret;
-	uint32_t timeout = BUF_READ_TIMEOUT;
-	uint32_t spirxdma_ndtr;
-	static uint8_t local_tx_data[32] = { 0x0 };
-
-	if (ad4692_data_capture_mode == BURST) {
-		nb_of_samples = nb_of_samples * BYTES_PER_SAMPLE;
-
-		ret = no_os_cb_prepare_async_write(iio_dev_data->buffer->buf,
-						   nb_of_samples,
-						   (void **) &buff_start_addr,
-						   &data_read);
-		if (ret) {
-			return ret;
-		}
-
-		/* Manipulate the number of samples considering the 2-cycle offset in manual mode*/
-		if (num_of_active_channels <= 2) {
-			nb_of_samples += (N_CYCLE_OFFSET * BYTES_PER_SAMPLE);
-		} else {
-			nb_of_samples += (num_of_active_channels * BYTES_PER_SAMPLE);
-		}
-
-		if (!dma_config_updated) {
-			ad4692_init_params.conv_param->period_ns = CONV_TRIGGER_PERIOD_NSEC(
-						ad4692_sampling_frequency);
-			ad4692_init_params.conv_param->duty_cycle_ns = CNV_ON_TIME;
-
-			ret = init_pwm();
-			if (ret) {
-				return ret;
-			}
-
-			/* Build the Tx command with respect to the enabled channels */
-			ad4692_get_tx_command(local_tx_data);
-
-			/* Cap SPI RX DMA NDTR to MAX_DMA_NDTR. */
-			spirxdma_ndtr = no_os_min(MAX_DMA_NDTR, nb_of_samples);
-			rxdma_ndtr = spirxdma_ndtr;
-
-			/* Register half complete callback, for ping-pong buffers implementation. */
-			HAL_DMA_RegisterCallback(&hdma_spi1_rx,
-						 HAL_DMA_XFER_HALFCPLT_CB_ID,
-						 ad4692_spi_dma_rx_half_cplt_callback);
-
-			struct no_os_spi_msg  ad4692_spi_msg = {
-				.tx_buff = local_tx_data,
-				.rx_buff = local_buf,
-				.bytes_number = spirxdma_ndtr,
-			};
-
-			ret = no_os_spi_transfer_dma_async(ad4692_dev->comm_desc, &ad4692_spi_msg,
-							   1, NULL, NULL);
-			if (ret) {
-				return ret;
-			}
-
-			/* DMA to be disabled while reconfiguring the NDTR register */
-			DMA2_Stream2->CR &= ~1;
-			DMA2_Stream2->NDTR = num_of_active_channels * 2;
-			DMA2_Stream2->CR |= 1;
-
-			dma_config_updated = true;
-		}
-
-		if (nb_of_samples == rxdma_ndtr) {
-			dma_cycle_count = 1;
-		} else {
-			dma_cycle_count = ((nb_of_samples) / rxdma_ndtr) + 1;
-		}
-		callback_count = dma_cycle_count * 2;
-		update_buff(local_buf, (uint8_t *)buff_start_addr);
-
-		/* Configure CNV PWM and start */
-		ret = ad4692_config_and_start_pwm(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-
-		while (ad4692_dma_buff_full != true && timeout > 0) {
-			timeout--;
-		}
-
-		if (!timeout) {
-			return -EIO;
-		}
-
-		ad4692_dma_buff_full = false;
-		ret = no_os_cb_end_async_write(iio_dev_data->buffer->buf);
-		if (ret) {
-			return ret;
-		}
-		ad4692_stop_timer();
-	} else { // CONTINUOUS_DATA_CAPTURE
-		if (!dma_config_updated) {
-			ad4692_init_params.conv_param->period_ns = CONV_TRIGGER_PERIOD_NSEC(
-						ad4692_sampling_frequency);
-			ad4692_init_params.conv_param->duty_cycle_ns = CNV_ON_TIME;
-
-			ret = init_pwm();
-			if (ret) {
-				return ret;
-			}
-
-			/* Build the Tx command with respect to the enabled channels */
-			ad4692_get_tx_command(local_tx_data);
-
-			nb_of_samples = nb_of_samples * BYTES_PER_SAMPLE;
-
-			/* Manipulate the number of samples considering the 2-cycle offset in manual mode*/
-			if (num_of_active_channels <= 2) {
-				nb_of_samples += (N_CYCLE_OFFSET * BYTES_PER_SAMPLE);
-			} else {
-				nb_of_samples += (num_of_active_channels * BYTES_PER_SAMPLE);
-			}
-
-			nb_of_samples_g = nb_of_samples;
-			iio_dev_data_g = iio_dev_data;
-
-			spirxdma_ndtr = no_os_min(MAX_DMA_NDTR, nb_of_samples);
-			rxdma_ndtr = spirxdma_ndtr;
-
-			/* SPI Message */
-			struct no_os_spi_msg ad4692_spi_msg = {
-				.tx_buff = local_tx_data,
-				.rx_buff = local_buf,
-				.bytes_number = spirxdma_ndtr
-			};
-
-			ret = no_os_cb_prepare_async_write(iio_dev_data_g->buffer->buf,
-							   nb_of_samples,
-							   (void **) &buff_start_addr,
-							   &data_read);
-			if (ret) {
-				return ret;
-			}
-
-			ret = no_os_spi_transfer_dma_async(ad4692_dev->comm_desc, &ad4692_spi_msg, 1,
-							   NULL, NULL);
-			if (ret) {
-				return ret;
-			}
-
-			/* DMA to be disabled while configuring the NDTR Register */
-			DMA2_Stream2->CR &= ~1;
-			DMA2_Stream2->NDTR = num_of_active_channels * BYTES_PER_SAMPLE;
-			DMA2_Stream2->CR |= 1;
-
-			dma_config_updated = true;
-
-			if (nb_of_samples == rxdma_ndtr) {
-				dma_cycle_count = 1;
-			} else {
-				dma_cycle_count = ((nb_of_samples) / rxdma_ndtr) + 1;
-			}
-
-			/* Update Buffer indices */
-			update_buff(local_buf, (uint8_t *)buff_start_addr);
-
-			/* Configure CNV PWM and start */
-			ret = ad4692_config_and_start_pwm(ad4692_dev);
-			if (ret) {
-				return ret;
-			}
-		}
-	}
-
-	return 0;
-}
-
-/**
- * @brief Read buffer data corresponding to AD4692 IIO device.
- * @param [in, out] iio_dev_data - Device descriptor.
- * @return Number of samples read.
- */
-static int32_t ad4692_iio_submit_samples(struct iio_device_data *iio_dev_data)
-{
-	int ret;
-	uint32_t timeout = BUF_READ_TIMEOUT;
-	uint32_t sample_index = 0;
-	ad4692_conversion_flag = false;
-	chan_id = 0;
-	uint32_t data_read;
-	uint8_t eoc_status;
-	uint8_t id = 0;
-	uint8_t bytes_offset = 2; // Offset to start reading the Rx word from SPI Data
-
-	if (!iio_dev_data) {
-		return -EINVAL;
-	}
-
-	nb_of_samples = iio_dev_data->buffer->size / n_data_bytes;
-
-	if (!buf_size_updated) {
-		/* Update total buffer size according to bytes per scan for proper
-		 * alignment of multi-channel IIO buffer data */
-		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
-		buf_size_updated = true;
-	}
-
-	if (ad4692_interface_mode == SPI_INTR) {
-		/* Start ADC data capture */
-		ret = ad4692_start_data_capture(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-
-		/* Clear any pending interrupts occured from a spurious falling edge of
-		* GPIO pin during toggling the CNV as a GPIO in the ad4692_start_data_capture()*/
-		if (ad4692_init_params.mode != AD4692_SPI_BURST) {
-			ret = no_os_irq_clear_pending(trigger_irq_desc, TRIGGER_INT_ID);
-			if (ret) {
-				return ret;
-			}
-		}
-
-		ret = no_os_irq_enable(trigger_irq_desc, trigger_gpio_irq_params.irq_ctrl_id);
-		if (ret) {
-			return ret;
-		}
-
-		/* Config CNV PWM and start */
-		ret = ad4692_config_and_start_pwm(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-
-		while (sample_index < nb_of_samples) {
-			/* Build the Tx Command */
-			ad4692_get_tx_command(acc_data_buff);
-
-			if (ad4692_init_params.mode == AD4692_SPI_BURST) {
-				/* Write to Convert Start register to trigger the next burst of conversion */
-				ret = ad4692_reg_write(ad4692_dev,
-						       AD4692_OSC_EN_REG,
-						       AD4692_CONV_START_MASK);
-				if (ret) {
-					return ret;
-				}
-			}
-
-			/* Check for status of conversion flag */
-			while (!ad4692_conversion_flag && timeout > 0) {
-				timeout--;
-			}
-
-			if (timeout == 0) {
-				return -ETIMEDOUT;
-			}
-			timeout = BUF_READ_TIMEOUT;
-
-			ad4692_conversion_flag = false;
-
-			if (ad4692_init_params.mode == AD4692_MANUAL_MODE) {
-				if (chan_id >= num_of_active_channels) {
-					chan_id = 0;
-				}
-
-				data_buff[0] = AD4692_IN_COMMAND(ad4692_active_channels[chan_id++]);
-				data_buff[1] = 0x0;
-
-				ret = no_os_spi_transfer(ad4692_dev->comm_desc, &ad4692_spi_msg_manual_mode, 1);
-				if (ret) {
-					return ret;
-				}
-
-				ret = no_os_cb_write(iio_dev_data->buffer->buf,
-						     ad4692_spi_msg_manual_mode.rx_buff,
-						     n_data_bytes);
-				if (ret) {
-					return ret;
-				}
-
-			} else {
-				if (ad4692_init_params.mode == AD4692_SPI_BURST) {
-					/* Poll for BSY Low */
-					do {
-						ret = no_os_gpio_get_value(ad4692_dev->gpio0_desc, &eoc_status);
-						if (ret) {
-							return ret;
-						}
-					} while ((eoc_status != NO_OS_GPIO_LOW) && (timeout-- > 0));
-
-					if (timeout == 0) {
-						return -ETIMEDOUT;
-					}
-					timeout = BUF_READ_TIMEOUT;
-				}
-
-				/* Pull CS low, read the data of all channels and Pull back CS High */
-				ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_LOW);
-				if (ret) {
-					return ret;
-				}
-
-				ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
-							       num_of_active_channels * n_bytes_per_transaction);
-				if (ret) {
-					return ret;
-				}
-
-				ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_HIGH);
-				if (ret) {
-					return ret;
-				}
-
-				for (chan_id = 0; chan_id < num_of_active_channels; chan_id++) {
-					id = (chan_id * n_bytes_per_transaction) + bytes_offset;
-					if (ad4692_readback_option == ACCUMULATOR_DATA) {
-						data_read = no_os_get_unaligned_be24(&acc_data_buff[id]);
-					} else {
-						data_read = no_os_get_unaligned_be16(&acc_data_buff[id]);
-					}
-
-					ret = no_os_cb_write(iio_dev_data->buffer->buf,
-							     &data_read,
-							     n_data_bytes);
-					if (ret) {
-						return ret;
-					}
-				}
-
-				/* Reset the state of accumulator to start a new burst of conversion*/
-				ret = ad4692_reg_write(ad4692_dev,
-						       AD4692_STATE_RESET_REG,
-						       AD4692_STATE_RESET_ALL);
-				if (ret) {
-					return ret;
-				}
-			}
-			sample_index++;
-		}
-
-		/* Stop timer */
-		ad4692_stop_timer();
-
-		/* Disable triggers */
-		ret = no_os_irq_disable(trigger_irq_desc, trigger_gpio_irq_params.irq_ctrl_id);
-		if (ret) {
-			return ret;
-		}
-
-		/* Stop ADC Data capture */
-		ret = ad4692_stop_data_capture(ad4692_dev);
-		if (ret) {
-			return ret;
-		}
-	} else { // SPI_DMA
-		ret = ad4692_read_data_spi_dma(nb_of_samples, iio_dev_data);
-		if (ret) {
-			return ret;
-		}
-	}
-
-	return 0;
 }
 
 /*!
@@ -2095,7 +732,7 @@ static int32_t ad4692_iio_debug_reg_read(void *dev,
 		uint32_t reg,
 		uint32_t *readval)
 {
-	int ret;
+	int32_t ret;
 
 	if (!readval || (reg > AD4692_ACC_STS_DATA_REG(NO_OF_CHANNELS))) {
 		return -EINVAL;
@@ -2120,7 +757,7 @@ static int32_t ad4692_iio_debug_reg_write(void *dev,
 		uint32_t reg,
 		uint32_t writeval)
 {
-	int ret;
+	int32_t ret;
 
 	if (reg > AD4692_ACC_STS_DATA_REG(NO_OF_CHANNELS)) {
 		return -EINVAL;
@@ -2156,12 +793,9 @@ static int ad4692_iio_init(struct iio_device **desc, uint8_t dev_indx)
 
 	ad4692_iio_inst = no_os_calloc(1, sizeof(struct iio_device));
 	if (!ad4692_iio_inst) {
-		return -EINVAL;
+		return -ENOMEM;
 	}
 
-	/* The acc_depth attribute is a global level attribute in case of Standard Sequencer
-	 * and a channel level attribute in case of the Advanced sequencer */
-	/* Update the channel map structure according to the sequencer configurations */
 	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
 		for (ch = 0; ch < AD4692_MAX_CHANNELS; ch++) {
 			channels[ch] = ad4692_iio_channels[dev_indx][ch];
@@ -2229,14 +863,14 @@ static int ad4692_iio_init(struct iio_device **desc, uint8_t dev_indx)
 	ad4692_iio_inst->num_ch = total_enabled_channels;
 	ad4692_iio_inst->channels = channels;
 	ad4692_iio_inst->attributes = ad4692_iio_global_attributes[dev_indx];
-	ad4692_iio_inst->submit = ad4692_iio_submit_samples;
-	ad4692_iio_inst->pre_enable = ad4692_iio_prepare_transfer;
-	ad4692_iio_inst->post_disable = ad4692_iio_end_transfer;
+	ad4692_iio_inst->submit = ad4692_data_transfer_submit;
+	ad4692_iio_inst->pre_enable = ad4692_data_transfer_prepare;
+	ad4692_iio_inst->post_disable = ad4692_data_transfer_end;
 	ad4692_iio_inst->debug_reg_read = ad4692_iio_debug_reg_read;
 	ad4692_iio_inst->debug_reg_write = ad4692_iio_debug_reg_write;
 
-	if (ad4692_data_capture_mode == CONTINUOUS) {
-		ad4692_iio_inst->trigger_handler = ad4692_trigger_handler;
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ad4692_iio_inst->trigger_handler = ad4692_data_transfer_trigger_handler;
 	}
 
 	/* Configure the endianness in Channel scan structure */
@@ -2247,15 +881,14 @@ static int ad4692_iio_init(struct iio_device **desc, uint8_t dev_indx)
 	} else {
 		endianness = false;
 
-		/* Update the scan structure according to the chosen readback option */
 		if (ad4692_readback_option == AVERAGED_DATA) {
 			realbits = AD4692_RES_16;
 			n_data_bytes = sizeof(uint16_t);
-			n_bytes_per_transaction = AD4692_N_BYTES_CNV_CLOCK_16BIT;
+			n_bytes_per_transaction = AD4692_N_BYTES_TXN_16BIT;
 		} else {
 			realbits = AD4692_RES_24;
 			n_data_bytes = sizeof(uint32_t);
-			n_bytes_per_transaction = AD4692_N_BYTES_CNV_CLOCK_24BIT;
+			n_bytes_per_transaction = AD4692_N_BYTES_TXN_24BIT;
 		}
 	}
 
@@ -2276,9 +909,9 @@ static int ad4692_iio_init(struct iio_device **desc, uint8_t dev_indx)
  * @param 	desc[in,out] - IIO hardware trigger descriptor
  * @return	0 in case of success, negative error code otherwise
  */
-static int ad4692_iio_trigger_param_init(struct iio_hw_trig **desc)
+static int32_t ad4692_iio_trigger_param_init(struct iio_hw_trig **desc)
 {
-	int ret;
+	int32_t ret;
 	struct iio_hw_trig_init_param ad4692_hw_trig_init_params;
 	struct iio_hw_trig *hw_trig_desc;
 
@@ -2352,75 +985,6 @@ static int board_iio_params_init(struct iio_device** desc,
 	return 0;
 }
 
-int32_t ad4692_configure_sampling_rate(void)
-{
-	dma_capture = false;
-
-	switch (ad4692_init_params.mode) {
-	case AD4692_MANUAL_MODE:
-		if (ad4692_interface_mode == SPI_DMA) {
-			dma_capture = true;
-			ad4692_sampling_frequency_max = S_RATE_MANUAL_DMA;
-		} else {
-			ad4692_sampling_frequency_max = S_RATE_MANUAL_INTR;
-		}
-
-		break;
-
-	case AD4692_CNV_CLOCK:
-		if (ad4692_readback_option == AVERAGED_DATA) {
-			ad4692_sampling_frequency_max = (ad4692_sequencer_mode == STANDARD_SEQUENCER) ?
-							S_RATE_CNV_CLOCK_INTR_STD_AVG :
-							S_RATE_CNV_CLOCK_INTR_ADV_AVG;
-		} else {
-			ad4692_sampling_frequency_max = (ad4692_sequencer_mode == STANDARD_SEQUENCER) ?
-							S_RATE_CNV_CLOCK_INTR_STD_ACC :
-							S_RATE_CNV_CLOCK_INTR_ADV_ACC;
-		}
-
-		break;
-
-	case AD4692_CNV_BURST:
-		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-			if (ad4692_readback_option  == AVERAGED_DATA) {
-				ad4692_sampling_frequency_max = S_RATE_CNV_BURST_STD_AVG;
-			} else {
-				ad4692_sampling_frequency_max = S_RATE_CNV_BURST_STD_ACC;
-			}
-		} else {
-			if (ad4692_readback_option  == AVERAGED_DATA) {
-				ad4692_sampling_frequency_max = S_RATE_CNV_BURST_ADV_AVG;
-			} else {
-				ad4692_sampling_frequency_max = S_RATE_CNV_BURST_ADV_ACC;
-			}
-		}
-
-		break;
-
-	case AD4692_SPI_BURST:
-		if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-			if (ad4692_readback_option  == AVERAGED_DATA) {
-				ad4692_sampling_frequency_max = S_RATE_SPI_BURST_STD_AVG;
-			} else {
-				ad4692_sampling_frequency_max = S_RATE_SPI_BURST_STD_ACC;
-			}
-		} else {
-			if (ad4692_readback_option  == AVERAGED_DATA) {
-				ad4692_sampling_frequency_max = S_RATE_SPI_BURST_ADV_AVG;
-			} else {
-				ad4692_sampling_frequency_max = S_RATE_SPI_BURST_ADV_ACC;
-			}
-		}
-
-		break;
-
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 /**
  * @brief	DeInitialize the IIO parameters.
  */
@@ -2441,16 +1005,14 @@ void iio_params_deinit(void)
 
 /**
  * @brief	Remove the IIO application and free the allocated resources
- * @return  None
+ * @return  0
  */
 int32_t iio_app_remove(void)
 {
-	/* Remove and free the pointers allocated during IIO init.
-	 * Use NULL checks to determine which resources were allocated,
-	 * since attribute setters may have changed mode globals before
-	 * the restart flag was set. */
+	/* Remove data transfer system */
+	ad4692_data_transfer_remove(ad4692_dev);
 
-	/* Remove hardware trigger if allocated (SPI_INTR + CONTINUOUS) */
+	/* Remove hardware trigger if allocated (SPI_INTR + CONTINUOUS_DATA_CAPTURE) */
 	if (ad4692_hw_trig_desc) {
 		iio_hw_trig_remove(ad4692_hw_trig_desc);
 		ad4692_hw_trig_desc = NULL;
@@ -2461,8 +1023,6 @@ int32_t iio_app_remove(void)
 
 	/* Remove SPI burst PWM if allocated (SPI_INTR + SPI_BURST) */
 	remove_pwm();
-
-	remove_gpio();
 
 	NO_OS_UNUSED_PARAM(ad4692_remove(ad4692_dev));
 	ad4692_dev = NULL;
@@ -2484,7 +1044,10 @@ int32_t iio_app_remove(void)
  */
 int32_t iio_app_initialize(void)
 {
-	int ret;
+	int32_t ret;
+
+	/* EVB HW validation status */
+	bool hw_mezzanine_is_valid;
 
 	static struct iio_trigger ad4692_iio_trig_desc = {
 		.is_synchronous = true,
@@ -2506,31 +1069,27 @@ int32_t iio_app_initialize(void)
 	}
 
 	if ((ad4692_interface_mode == SPI_INTR)
-	    && (ad4692_data_capture_mode == CONTINUOUS)) {
+	    && (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE)) {
 		iio_init_params.trigs = &iio_trigger_init_params;
 	}
-
-	/* Configure max permissible data rate */
-	ret = ad4692_configure_sampling_rate();
-	if (ret) {
-		return ret;
-	}
-
-	ad4692_sampling_frequency = ad4692_sampling_frequency_max;
 
 	/* Configure to Standard Sequencer in manual Mode */
 	if (ad4692_init_params.mode == AD4692_MANUAL_MODE) {
 		ad4692_sequencer_mode = STANDARD_SEQUENCER;
 	}
 
+	/* Set the PWM period based on the mode */
+	ad4692_sampling_frequency = ad4692_get_max_sampling_rate(
+					    ad4692_init_params.mode);
+	if (ad4692_sampling_frequency) {
+		pwm_init_convst.period_ns = CONV_TRIGGER_PERIOD_NSEC(ad4692_sampling_frequency);
+		pwm_init_convst.duty_cycle_ns = CNV_ON_TIME;
+	}
+
 	ret = init_interrupt();
 	if (ret) {
 		return ret;
 	}
-
-	pwm_init_convst.period_ns = CONV_TRIGGER_PERIOD_NSEC(ad4692_sampling_frequency);
-	pwm_spi_burst_init.period_ns = CONV_TRIGGER_PERIOD_NSEC(
-					       ad4692_sampling_frequency);
 
 	/* Read context attributes */
 	ret = get_iio_context_attributes_ex(&iio_init_params.ctx_attrs,
@@ -2552,22 +1111,24 @@ int32_t iio_app_initialize(void)
 		}
 
 		/* Exit from manual mode if device is configured to manual mode */
-		ret = ad4692_stop_data_capture(ad4692_dev);
-		if (ret) {
-			goto err_remove_ad4692;
+		if (ad4692_dev->mode == AD4692_MANUAL_MODE) {
+			ret = ad4692_exit_manual_mode(ad4692_dev);
+			if (ret) {
+				goto err_remove_ad4692_dev;
+			}
 		}
 
 		/* Register and initialize the AD4692 device into IIO interface */
 		ret = ad4692_iio_init(&ad4692_iio_dev[0], 0);
 		if (ret) {
-			goto err_remove_ad4692;
+			goto err_remove_ad4692_dev;
 		}
 
 		/* Initialize the IIO interface */
 		iio_device_init_params[0].name = ACTIVE_DEVICE_NAME;
 		iio_device_init_params[0].raw_buf = (int8_t *)adc_data_buffer +
 						    (N_CYCLE_OFFSET * BYTES_PER_SAMPLE);
-		if (ad4692_data_capture_mode == CONTINUOUS) {
+		if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
 			iio_device_init_params[0].raw_buf_len = DATA_BUFFER_SIZE_CONT;
 		} else {
 			iio_device_init_params[0].raw_buf_len = DATA_BUFFER_SIZE;
@@ -2578,18 +1139,52 @@ int32_t iio_app_initialize(void)
 		iio_init_params.nb_devs++;
 
 		if ((ad4692_interface_mode == SPI_INTR)
-		    && (ad4692_data_capture_mode == CONTINUOUS)) {
+		    && (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE)) {
 			iio_device_init_params[0].trigger_id = "trigger0";
 			iio_init_params.nb_trigs++;
 		}
-
 		break;
+	} while (false);
+
+	if (ad4692_dev) {
+		/* Configure the channel priorities in advanced sequencer mode */
+		if (ad4692_sequencer_mode == ADVANCED_SEQUENCER) {
+			ret = ad4692_configure_channel_priorities(channel_priorities,
+					channel_sequence,
+					&num_of_as_slots,
+					ad4692_acc_count);
+			if (ret) {
+				goto err_remove_ad4692;
+			}
+		} else {
+			memset(ad4692_acc_count, 0x0, NO_OF_CHANNELS);
+		}
+
+		/* Initialize data transfer system for selected mode */
+		/*
+		 * Note: ad4692_init_params.mode is used instead of ad4692_dev->mode
+		 * because when ad4692_init_params.mode is MANUAL the device moves to
+		 * MANUAL mode only when data capture occurs. The ADC doesn't accept
+		 * any register read/write when in MANUAL mode. Hence use CNV_CLOCK
+		 * mode for all register read/write and use MANUAL mode only for data
+		 * capture.
+		 */
+		ret = ad4692_data_transfer_init(ad4692_dev, ad4692_init_params.mode);
+		if (ret) {
+			goto err_remove_ad4692;
+		}
+	}
+
+	/* Goto System Config initialization if success */
+	goto system_config_init;
 
 err_remove_ad4692:
-		ad4692_remove(ad4692_dev);
-		ad4692_dev = NULL;
-		goto system_config_init;
-	} while (false);
+	no_os_free(ad4692_iio_dev[0]);
+	iio_init_params.nb_devs = 0;
+	iio_init_params.nb_trigs = 0;
+err_remove_ad4692_dev:
+	ad4692_remove(ad4692_dev);
+	ad4692_dev = NULL;
 
 system_config_init:
 	/* Initialize board IIO paramaters */
@@ -2613,32 +1208,10 @@ iio_init:
 	}
 
 	if ((ad4692_interface_mode == SPI_INTR)
-	    && (ad4692_data_capture_mode == CONTINUOUS)) {
+	    && (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE)) {
 		ret = ad4692_iio_trigger_param_init(&ad4692_hw_trig_desc);
 		if (ret) {
 			return ret;
-		}
-	}
-
-	/* Initialize the PWM and channel priorities only if ADC initialization is proper */
-	if (ad4692_dev) {
-		ret = init_pwm();
-		if (ret) {
-			return ret;
-		}
-		ad4692_stop_timer();
-
-		/* Configure the channel priorities in advanced sequencer mode */
-		if (ad4692_sequencer_mode == ADVANCED_SEQUENCER) {
-			ret = ad4692_configure_channel_priorities(channel_priorities,
-					channel_sequence,
-					&num_of_as_slots,
-					ad4692_acc_count);
-			if (ret) {
-				return ret;
-			}
-		} else {
-			memset(ad4692_acc_count, 0x0, NO_OF_CHANNELS);
 		}
 	}
 

--- a/projects/ad4692_iio/app/ad4692_iio.c
+++ b/projects/ad4692_iio/app/ad4692_iio.c
@@ -3,7 +3,7 @@
  *   @brief   Implementation of AD4692 IIO application interfaces
  *   @details This module acts as an interface for AD4692 IIO application
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * By using this software you agree to the terms of the associated

--- a/projects/ad4692_iio/app/ad4692_iio.h
+++ b/projects/ad4692_iio/app/ad4692_iio.h
@@ -2,7 +2,7 @@
 *   @file   ad4692_iio.h
 *   @brief  Header file of ad4692_iio
 ********************************************************************************
-* Copyright (c) 2024, 2026 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 * This software is proprietary to Analog Devices, Inc. and its licensors.

--- a/projects/ad4692_iio/app/ad4692_iio.h
+++ b/projects/ad4692_iio/app/ad4692_iio.h
@@ -38,8 +38,8 @@ enum ad4692_interface_modes {
 
 /* Enum of data capture modes */
 enum ad4692_data_capture_modes {
-	CONTINUOUS,
-	BURST
+	CONTINUOUS_DATA_CAPTURE,
+	BURST_DATA_CAPTURE
 };
 
 /* AD4692 attribute unique IDs */
@@ -80,6 +80,5 @@ extern struct ad4692_desc *ad4692_dev;
 extern uint32_t ad4692_sampling_frequency;
 extern enum ad4692_interface_modes ad4692_interface_mode;
 extern enum ad4692_data_capture_modes ad4692_data_capture_mode;
-extern uint8_t buf_offset;
 
 #endif /* AD4692_IIO_H_ */

--- a/projects/ad4692_iio/app/ad4692_support.c
+++ b/projects/ad4692_iio/app/ad4692_support.c
@@ -117,30 +117,23 @@ int32_t ad4692_data_transfer_read_converted_data(struct ad4692_desc *desc,
 void ad4692_update_active_channels(uint32_t ch_mask)
 {
 	uint8_t ch_id;
-	uint8_t index;
-	uint32_t mask;
 
 	num_of_active_channels = 0;
 	memset(ad4692_active_channels, 0, NO_OF_CHANNELS);
 
 	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
-		for (ch_id = 0, index = 0, mask = 0x1; ch_id < NO_OF_CHANNELS; ch_id++) {
-			if (mask & ch_mask) {
-				ad4692_active_channels[index++] = ch_id;
-				num_of_active_channels++;
+		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
+			if (ch_mask & NO_OS_BIT(ch_id)) {
+				ad4692_active_channels[num_of_active_channels++] = ch_id;
 			}
-			mask <<= 1;
 		}
 		channel_mask = ch_mask;
 	} else {
-		for (ch_id = 0, index = 0, mask = 0x1; ch_id < NO_OF_CHANNELS; ch_id++) {
+		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
 			if (channel_priorities[ch_id] != 0) {
-				ad4692_active_channels[index++] = ch_id;
-				num_of_active_channels++;
-				mask |= (1 << ch_id);
+				ad4692_active_channels[num_of_active_channels++] = ch_id;
 			}
 		}
-		channel_mask = mask;
 	}
 
 	return;
@@ -340,7 +333,7 @@ int ad4692_configure_acc_mask(uint16_t channel_mask,
 		/* Build the channel mask depending on the channel priorities set */
 		for (ch_id = 0; ch_id < NO_OF_CHANNELS; ch_id++) {
 			if (chn_priorities[ch_id] > 0) {
-				chn_mask &= ~(1 << ch_id);
+				chn_mask &= ~NO_OS_BIT(ch_id);
 			}
 		}
 	}

--- a/projects/ad4692_iio/app/ad4692_support.c
+++ b/projects/ad4692_iio/app/ad4692_support.c
@@ -2,7 +2,7 @@
  *   @file   ad4692_support.c
  *   @brief  Support file for AD4692 device
 ******************************************************************************
-* Copyright (c) 2024 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad4692_iio/app/ad4692_support.c
+++ b/projects/ad4692_iio/app/ad4692_support.c
@@ -15,12 +15,14 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
+#include "string.h"
 #include "ad4692_support.h"
+#include "ad4692_iio.h"
+#include "app_config.h"
+
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "app_config.h"
-#include "ad4692_iio.h"
-#include "string.h"
+#include "no_os_util.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definition ***********************/
@@ -30,36 +32,290 @@
 /********************** Variables and User Defined Data Types *****************/
 /******************************************************************************/
 
+/* Flag to indicate if size of the buffer is updated according to requested
+ * number of samples for the multi-channel IIO buffer data alignment */
+volatile bool buf_size_updated = false;
+
+/* Active mode data transfer system pointer */
+static struct ad4692_data_transfer_system *ad4692_active_mode;
+
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
 /**
- * @brief Toggle CNV GPIO
- * @param gpio_cnv[in, out] - GPIO CNV Descriptor
- * @return 0 in case of success, negative error code otherwise.
+ * @brief Initialize the data transfer system for a given ADC mode
+ * @param desc[in] - AD4692 device descriptor
+ * @param mode[in] - ADC mode to initialize
+ * @return 0 in case of success, negative error code otherwise
  */
-int ad4692_toggle_cnv(struct no_os_gpio_desc* gpio_cnv)
+int32_t ad4692_data_transfer_init(struct ad4692_desc *desc,
+				  enum ad4692_spi_mode mode)
 {
-	int ret;
+	int32_t ret;
 
-	if (!gpio_cnv) {
-		return -EINVAL;
-	}
-
-	ret = no_os_gpio_set_value(gpio_cnv, NO_OS_GPIO_HIGH);
+	ret = init_pwm();
 	if (ret) {
 		return ret;
 	}
 
-	no_os_udelay(1);
+	switch (mode) {
+	case AD4692_MANUAL_MODE:
+		ad4692_active_mode = &ad4692_data_transfer_manual_mode;
+		break;
+	case AD4692_CNV_CLOCK:
+		ad4692_active_mode = &ad4692_data_transfer_cnv_clock_mode;
+		break;
+	case AD4692_CNV_BURST:
+		ad4692_active_mode = &ad4692_data_transfer_cnv_burst_mode;
+		break;
+	case AD4692_SPI_BURST:
+		ad4692_active_mode = &ad4692_data_transfer_spi_burst_mode;
+		break;
+	default:
+		return -EINVAL;
+	}
 
-	ret = no_os_gpio_set_value(gpio_cnv, NO_OS_GPIO_LOW);
+	if (ad4692_active_mode->initialize) {
+		ret = ad4692_active_mode->initialize(desc);
+	}
+
 	if (ret) {
+		NO_OS_UNUSED_PARAM(remove_pwm());
 		return ret;
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Delegation: read converted data from active mode
+ * @param desc[in] - AD4692 device descriptor
+ * @param chn[in] - Channel number to read
+ * @param adc_data[out] - Pointer to store the converted data
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad4692_data_transfer_read_converted_data(struct ad4692_desc *desc,
+		uint8_t chn, uint32_t *adc_data)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->read_converted_data) {
+		return ad4692_active_mode->read_converted_data(desc, chn, adc_data);
+	}
+
+	return -ENOSYS;
+}
+
+
+/**
+ * @brief Update active channels based on sequencer mode and channel mask
+ * @param ch_mask[in] - Channel mask (used in standard sequencer mode)
+ */
+void ad4692_update_active_channels(uint32_t ch_mask)
+{
+	uint8_t ch_id;
+	uint8_t index;
+	uint32_t mask;
+
+	num_of_active_channels = 0;
+	memset(ad4692_active_channels, 0, NO_OF_CHANNELS);
+
+	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
+		for (ch_id = 0, index = 0, mask = 0x1; ch_id < NO_OF_CHANNELS; ch_id++) {
+			if (mask & ch_mask) {
+				ad4692_active_channels[index++] = ch_id;
+				num_of_active_channels++;
+			}
+			mask <<= 1;
+		}
+		channel_mask = ch_mask;
+	} else {
+		for (ch_id = 0, index = 0, mask = 0x1; ch_id < NO_OF_CHANNELS; ch_id++) {
+			if (channel_priorities[ch_id] != 0) {
+				ad4692_active_channels[index++] = ch_id;
+				num_of_active_channels++;
+				mask |= (1 << ch_id);
+			}
+		}
+		channel_mask = mask;
+	}
+
+	return;
+}
+
+/**
+ * @brief Delegation: prepare transfer for active mode
+ * @param dev[in] - IIO device instance
+ * @param ch_mask[in] - Channel mask indicating which channels to enable
+ * @return 0 in case of success, -EINVAL if no active mode, 0 if function not implemented
+ */
+int32_t ad4692_data_transfer_prepare(void *dev, uint32_t ch_mask)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->prepare_transfer) {
+		return ad4692_active_mode->prepare_transfer(dev, ch_mask);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Delegation: end transfer for active mode
+ * @param dev[in] - IIO device instance
+ * @return 0 in case of success, -EINVAL if no active mode, 0 if function not implemented
+ */
+int32_t ad4692_data_transfer_end(void *dev)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->end_transfer) {
+		return ad4692_active_mode->end_transfer(dev);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Delegation: remove active mode resources
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, -EINVAL if no active mode, 0 if function not implemented
+ */
+int32_t ad4692_data_transfer_remove(struct ad4692_desc *desc)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->remove) {
+		return ad4692_active_mode->remove(desc);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Delegation: submit samples for active mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success, -EINVAL if no active mode, 0 if function not implemented
+ */
+int32_t ad4692_data_transfer_submit(struct iio_device_data *iio_dev_data)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->submit_samples) {
+		return ad4692_active_mode->submit_samples(iio_dev_data);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Delegation: trigger handler for active mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success, -EINVAL if no active mode, 0 if function not implemented
+ */
+int32_t ad4692_data_transfer_trigger_handler(struct iio_device_data
+		*iio_dev_data)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->trigger_handler) {
+		return ad4692_active_mode->trigger_handler(iio_dev_data);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Delegation: update sampling frequency for active mode
+ * @param sampling_rate[in,out] - Pointer to requested/actual sampling rate
+ * @return 0 in case of success, -EINVAL if no active mode, 0 if function not implemented
+ */
+int32_t ad4692_data_transfer_update_freq(uint32_t *sampling_rate)
+{
+	if (!ad4692_active_mode) {
+		return -EINVAL;
+	}
+
+	if (ad4692_active_mode->update_sampling_frequency) {
+		return ad4692_active_mode->update_sampling_frequency(sampling_rate);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get maximum sampling rate for a given ADC mode
+ * @param mode[in] - ADC mode
+ * @return Maximum sampling rate in samples per second
+ */
+uint32_t ad4692_get_max_sampling_rate(enum ad4692_spi_mode mode)
+{
+	switch (mode) {
+	case AD4692_MANUAL_MODE:
+		return ad4692_data_transfer_manual_mode.get_max_sampling_rate();
+	case AD4692_CNV_CLOCK:
+		return ad4692_data_transfer_cnv_clock_mode.get_max_sampling_rate();
+	case AD4692_CNV_BURST:
+		return ad4692_data_transfer_cnv_burst_mode.get_max_sampling_rate();
+	case AD4692_SPI_BURST:
+		return ad4692_data_transfer_spi_burst_mode.get_max_sampling_rate();
+	default:
+		return 0;
+	}
+}
+
+/**
+ * @brief  Get the Tx buffer respective to the enabled channels
+ * @param local_tx_data[out] - Tx buffer to populate with channel commands
+ * @return None
+ */
+void ad4692_get_tx_command(uint8_t *local_tx_data)
+{
+	uint8_t ch_id;
+	uint8_t index;
+
+	if (ad4692_interface_mode == SPI_DMA) {
+		for (ch_id = 0; ch_id < num_of_active_channels; ch_id++) {
+			index = ad4692_active_channels[ch_id];
+			local_tx_data[ch_id * BYTES_PER_SAMPLE] = AD4692_IN_COMMAND(index);
+			local_tx_data[(ch_id * BYTES_PER_SAMPLE) + 1] = 0;
+		}
+	} else {
+		index = 0;
+		for (ch_id = 0; ch_id < num_of_active_channels; ch_id++) {
+			if (ad4692_readback_option == ACCUMULATOR_DATA) {
+				local_tx_data[index++] = AD4692_RW_ADDR_MASK | AD4692_MSB_MASK(
+								 AD4692_ACC_IN_REG(
+										 ad4692_active_channels[ch_id]));
+				local_tx_data[index++] = AD4692_LSB_MASK(AD4692_ACC_IN_REG(
+								 ad4692_active_channels[ch_id]));
+				local_tx_data[index++] = 0x0;
+				local_tx_data[index++] = 0x0;
+				local_tx_data[index++] = 0x0;
+			} else {
+				local_tx_data[index++] = AD4692_RW_ADDR_MASK | AD4692_MSB_MASK(
+								 AD4692_AVG_IN_REG(
+										 ad4692_active_channels[ch_id]));
+				local_tx_data[index++] = AD4692_LSB_MASK(AD4692_AVG_IN_REG(
+								 ad4692_active_channels[ch_id]));
+				local_tx_data[index++] = 0x0;
+				local_tx_data[index++] = 0x0;
+			}
+		}
+	}
 }
 
 /**
@@ -70,7 +326,7 @@ int ad4692_toggle_cnv(struct no_os_gpio_desc* gpio_cnv)
  * @return 0 in case of success, negative error code otherwise.
  */
 int ad4692_configure_acc_mask(uint16_t channel_mask,
-			      enum ad4692_sequencer_modes sequencer, uint8_t* chn_priorities)
+			      enum ad4692_sequencer_modes sequencer, uint8_t *chn_priorities)
 {
 	int ret;
 	uint16_t chn_mask = 0xFFFF;
@@ -120,7 +376,7 @@ int ad4692_configure_acc_mask(uint16_t channel_mask,
  * Then the advanced sequencer configurations would look like:
  * Ch0-Ch1-Ch2-Ch3-Ch0-Ch1-Ch2-Ch4
  */
-int ad4692_configure_channel_priorities(uint8_t* chn_priorities,
+int ad4692_configure_channel_priorities(uint8_t *chn_priorities,
 					uint8_t *channel_sequence, uint8_t *num_of_as_slots, uint8_t *acc_count)
 {
 	uint8_t channel_sequence_p1[AD4692_MAX_SLOTS_AS] = { 0x0 };
@@ -233,18 +489,58 @@ int ad4692_configure_channel_priorities(uint8_t* chn_priorities,
 
 	return 0;
 }
+
 /**
- * @brief Exit manual mode and switch to CNV clock mode.
- *
- * @param desc Pointer to the AD4692 descriptor.
- * @param cnv_desc Pointer to the CNV GPIO descriptor.
- * @return int 0 on success, negative error code on failure.
+ * @brief Configure the per channel accumulator count limit and
+ *        enable the desired channels in the AD4692 device.
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
  */
-int ad4692_exit_manual_mode(struct ad4692_desc *desc,
-			    struct no_os_gpio_desc* cnv_desc)
+int ad4692_configure_channel(struct ad4692_desc *desc)
 {
 	int ret;
-	uint8_t toggle_n;
+	uint8_t ch_id;
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
+		/* Enable the desired channels */
+		ret = ad4692_std_seq_ch(desc, channel_mask, true, 0);
+		if (ret) {
+			return ret;
+		}
+
+		/* Configure accumulator mask */
+		ret = ad4692_configure_acc_mask(channel_mask, ad4692_sequencer_mode,
+						channel_priorities);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* Configure the accumulator count limit */
+	for (ch_id = 0; ch_id < num_of_active_channels; ch_id++) {
+		ret = ad4692_reg_write(desc,
+				       AD4692_ACC_COUNT_LIMIT_REG(ad4692_active_channels[ch_id]),
+				       ad4692_acc_count[ad4692_active_channels[ch_id]]);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Exit manual mode and switch to CNV clock mode.
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad4692_exit_manual_mode(struct ad4692_desc *desc)
+{
+	int ret;
 	uint8_t buff[BYTES_PER_SAMPLE] = { AD4692_EXIT_COMMAND, 0x0 };
 
 	struct no_os_spi_msg ad4692_spi_msg = {
@@ -254,13 +550,8 @@ int ad4692_exit_manual_mode(struct ad4692_desc *desc,
 		.bytes_number = BYTES_PER_SAMPLE
 	};
 
-	/* Toggle CNV at a gap of 5us */
-	for (toggle_n = 0; toggle_n < AD4692_N_CNV_TOGGLES; toggle_n++) {
-		no_os_udelay(5);
-		ret = ad4692_toggle_cnv(cnv_desc);
-		if (ret) {
-			return ret;
-		}
+	if (!desc) {
+		return -EINVAL;
 	}
 
 	ret = no_os_spi_transfer(desc->comm_desc, &ad4692_spi_msg, 1);
@@ -268,7 +559,54 @@ int ad4692_exit_manual_mode(struct ad4692_desc *desc,
 		return ret;
 	}
 
+	/* Temporary assignment of mode */
 	desc->mode = AD4692_CNV_CLOCK;
+
+	ret = ad4692_reg_update(desc, AD4692_ADC_SETUP_REG,
+				AD4692_MODE_MASK,
+				desc->mode);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Configure PWM with optimal prescaler for given sampling rate
+ * @param desc[in] - PWM descriptor to configure
+ * @param sampling_rate[in] - Desired sampling rate in samples per second
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad4692_configure_pwm_rate(struct no_os_pwm_desc *desc,
+			      uint32_t sampling_rate)
+{
+	int ret;
+	uint64_t pwm_period_ns;
+	uint32_t prescaler;
+
+	pwm_period_ns = CONV_TRIGGER_PERIOD_NSEC(sampling_rate);
+
+	ret = compute_optimal_prescaler(desc->extra,
+					pwm_period_ns, &prescaler);
+	if (ret) {
+		return ret;
+	}
+
+	ret = set_timer_prescaler(desc, prescaler);
+	if (ret) {
+		return ret;
+	}
+
+	ret = no_os_pwm_set_period(desc, pwm_period_ns);
+	if (ret) {
+		return ret;
+	}
+
+	ret = no_os_pwm_set_duty_cycle(desc, CNV_ON_TIME);
+	if (ret) {
+		return ret;
+	}
 
 	return 0;
 }

--- a/projects/ad4692_iio/app/ad4692_support.h
+++ b/projects/ad4692_iio/app/ad4692_support.h
@@ -2,7 +2,7 @@
  *   @file   ad4692_support.h
  *   @brief  Support header file for AD4692
 ******************************************************************************
-* Copyright (c) 2024 Analog Devices, Inc.
+* Copyright (c) 2024, 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *
@@ -19,6 +19,8 @@
 /******************************************************************************/
 
 #include "no_os_gpio.h"
+#include "iio.h"
+#include "iio_trigger.h"
 #include "ad4692.h"
 
 /******************************************************************************/
@@ -31,11 +33,23 @@
 /* Enable toggling of CS */
 #define CS_CHANGE		1
 
+/* Number of bytes per transaction for accumulator data */
+#define AD4692_N_BYTES_TXN_24BIT	5
+
+/* Number of bytes per transaction for averaged data */
+#define AD4692_N_BYTES_TXN_16BIT	4
+
+/* Number of bytes of command for data capture */
+#define AD4692_N_BYTES_TXN_OFFSET	2
+
 /* Number of CNV toggles to register the channel ID */
 #define AD4692_N_CNV_TOGGLES 2
 
 /* Exit manual mode */
 #define AD4692_EXIT_MANUAL_MODE	0x0
+
+/* Converts pwm period in nanoseconds to sampling frequency in samples per second */
+#define PWM_PERIOD_TO_FREQUENCY(x)       (1E9 / x)
 
 /******************************************************************************/
 /********************** Variables and User Defined Data Types *****************/
@@ -50,12 +64,83 @@ enum ad4692_sequencer_modes {
 	ADVANCED_SEQUENCER
 };
 
-int ad4692_toggle_cnv(struct no_os_gpio_desc* gpio_cnv);
-int ad4692_configure_channel_priorities(uint8_t* chn_priorities,
-					uint8_t* channel_sequence, uint8_t* num_as_slots, uint8_t *acc_count);
+/**
+ * @enum ad4692_readback_options
+ * @brief AD4692 readback options
+ */
+enum ad4692_readback_options {
+	AVERAGED_DATA,
+	ACCUMULATOR_DATA
+};
+
+/**
+ * @struct ad4692_data_transfer_system
+ * @brief AD4692 Data transfer system function pointers (per ADC mode)
+ */
+struct ad4692_data_transfer_system {
+	int32_t (*initialize)(struct ad4692_desc *desc);
+	int32_t (*prepare_transfer)(void *dev, uint32_t ch_mask);
+	int32_t (*submit_samples)(struct iio_device_data *iio_dev_data);
+	int32_t (*trigger_handler)(struct iio_device_data *iio_dev_data);
+	int32_t (*end_transfer)(void *dev);
+	int32_t (*remove)(struct ad4692_desc *desc);
+	int32_t (*read_converted_data)(struct ad4692_desc *desc, uint8_t chn,
+				       uint32_t *adc_data);
+	int32_t (*update_sampling_frequency)(uint32_t *sampling_rate);
+	uint32_t (*get_max_sampling_rate)(void);
+};
+
+/* Mode-specific data transfer system instances */
+extern struct ad4692_data_transfer_system ad4692_data_transfer_manual_mode;
+extern struct ad4692_data_transfer_system ad4692_data_transfer_cnv_clock_mode;
+extern struct ad4692_data_transfer_system ad4692_data_transfer_cnv_burst_mode;
+extern struct ad4692_data_transfer_system ad4692_data_transfer_spi_burst_mode;
+
+/* Shared state accessed by mode files */
+extern uint8_t ad4692_active_channels[];
+extern uint8_t num_of_active_channels;
+extern uint16_t channel_mask;
+extern uint8_t ad4692_acc_count[];
+extern uint8_t channel_priorities[];
+extern uint8_t n_data_bytes;
+extern uint8_t n_bytes_per_transaction;
+extern volatile bool ad4692_conversion_flag;
+extern volatile bool buf_size_updated;
+extern enum ad4692_sequencer_modes ad4692_sequencer_mode;
+extern enum ad4692_readback_options ad4692_readback_option;
+extern enum ad4692_int_osc_sel ad4692_osc_freq_id;
+extern struct iio_hw_trig *ad4692_hw_trig_desc;
+
+/******************************************************************************/
+/************************ Public Declarations *********************************/
+/******************************************************************************/
+
+/* Utility functions */
+int ad4692_configure_channel(struct ad4692_desc *desc);
+int ad4692_configure_channel_priorities(uint8_t *chn_priorities,
+					uint8_t* channel_sequence, uint8_t *num_as_slots, uint8_t *acc_count);
 int ad4692_configure_acc_mask(uint16_t channel_mask,
-			      enum ad4692_sequencer_modes sequencer, uint8_t* chn_priorities);
-int ad4692_exit_manual_mode(struct ad4692_desc *desc,
-			    struct no_os_gpio_desc* cnv_desc);
+			      enum ad4692_sequencer_modes sequencer, uint8_t *chn_priorities);
+int ad4692_exit_manual_mode(struct ad4692_desc *desc);
+int ad4692_configure_pwm_rate(struct no_os_pwm_desc *desc,
+			      uint32_t sampling_rate);
+void ad4692_get_tx_command(uint8_t *local_tx_data);
+
+/* Common utility functions */
+void ad4692_update_active_channels(uint32_t ch_mask);
+
+/* Delegation functions */
+int32_t ad4692_data_transfer_init(struct ad4692_desc *desc,
+				  enum ad4692_spi_mode mode);
+int32_t ad4692_data_transfer_prepare(void *dev, uint32_t ch_mask);
+int32_t ad4692_data_transfer_submit(struct iio_device_data *iio_dev_data);
+int32_t ad4692_data_transfer_trigger_handler(struct iio_device_data
+		*iio_dev_data);
+int32_t ad4692_data_transfer_end(void *dev);
+int32_t ad4692_data_transfer_remove(struct ad4692_desc *desc);
+int32_t ad4692_data_transfer_read_converted_data(struct ad4692_desc *desc,
+		uint8_t chn, uint32_t *adc_data);
+int32_t ad4692_data_transfer_update_freq(uint32_t *sampling_rate);
+uint32_t ad4692_get_max_sampling_rate(enum ad4692_spi_mode mode);
 
 #endif /* end of AD4692_SUPPORT_H */

--- a/projects/ad4692_iio/app/ad4692_support.h
+++ b/projects/ad4692_iio/app/ad4692_support.h
@@ -2,7 +2,7 @@
  *   @file   ad4692_support.h
  *   @brief  Support header file for AD4692
 ******************************************************************************
-* Copyright (c) 2024, 2026 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad4692_iio/app/ad4692_support_cnv_burst_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_cnv_burst_mode.c
@@ -1,0 +1,497 @@
+/***************************************************************************//**
+ *   @file    ad4692_support_cnv_burst_mode.c
+ *   @brief   AD4692 CNV Burst Mode data transfer implementation
+ *   @details Contains all data capture logic specific to CNV Burst Mode
+********************************************************************************
+ * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <string.h>
+
+#include "ad4692_support.h"
+#include "ad4692_iio.h"
+#include "ad4692_user_config.h"
+#include "no_os_error.h"
+#include "no_os_delay.h"
+#include "no_os_util.h"
+#include "app_config.h"
+#include "ad4692.h"
+#include "iio_trigger.h"
+
+/******************************************************************************/
+/************************ Macros/Constants ************************************/
+/******************************************************************************/
+
+#define BUF_READ_TIMEOUT	0xffffffff
+
+/* Stop State mask */
+#define AD4692_ADC_MODE_STOP_STATE_MASK  NO_OS_BIT(5)
+
+/* Data Ready Stop state */
+#define AD4692_STOP_STATE_DATA_READYb   0x1
+
+/* Number of bytes per transaction for accumulator data */
+#define AD4692_N_BYTES_CNV_BURST_24BIT	5
+
+/* Number of bytes per transaction for averaged data */
+#define AD4692_N_BYTES_CNV_BURST_16BIT	4
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/* Maximum sampling frequency for CNV burst mode */
+static uint32_t ad4692_sampling_frequency_max;
+
+/* Accumulator data buffer */
+static uint8_t acc_data_buff[AD4692_N_BYTES_CNV_BURST_24BIT *
+							    AD4692_MAX_CHANNELS] = { 0x0 };
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static uint32_t ad4692_cnv_burst_get_max_sampling_rate(void);
+static int32_t ad4692_cnv_burst_update_sampling_frequency(
+	uint32_t *sampling_rate);
+
+/**
+ * @brief Initialize CNV burst mode
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_burst_init(struct ad4692_desc *desc)
+{
+	int ret;
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	ad4692_sampling_frequency_max = ad4692_cnv_burst_get_max_sampling_rate();
+
+	ret = ad4692_cnv_burst_update_sampling_frequency(
+		      &ad4692_sampling_frequency_max);
+	if (ret) {
+		return ret;
+	}
+
+	/* Reset manual mode bit */
+	ret = ad4692_reg_update(desc,
+				AD4692_DEVICE_SETUP_REG,
+				AD4692_MANUAL_MODE_MASK,
+				AD4692_EXIT_MANUAL_MODE);
+	if (ret) {
+		return ret;
+	}
+
+	/* Reset the state of the accumulator */
+	ret = ad4692_reg_write(desc,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure GPIO0 as DATA_READYb */
+	ret = ad4692_reg_update(desc,
+				AD4692_GPIO_MODE1_REG,
+				AD4692_GPIO0_MASK,
+				AD4692_GPIO_OUTPUT_DATA_READYb);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure DATA_READYb as the stop state trigger */
+	ret = ad4692_reg_update(desc,
+				AD4692_ADC_SETUP_REG,
+				AD4692_ADC_MODE_STOP_STATE_MASK,
+				no_os_field_prep(AD4692_ADC_MODE_STOP_STATE_MASK,
+						AD4692_STOP_STATE_DATA_READYb));
+	if (ret) {
+		return ret;
+	}
+
+	/* Enter CNV Burst Mode */
+	ret = ad4692_reg_update(desc,
+				AD4692_ADC_SETUP_REG,
+				AD4692_MODE_MASK,
+				AD4692_CNV_BURST);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Prepare for ADC data transfer in CNV burst mode
+ * @param dev[in] - IIO device instance
+ * @param ch_mask[in] - Channels select mask
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_burst_prepare_transfer(void *dev,
+		uint32_t ch_mask)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	ad4692_update_active_channels(ch_mask);
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ret = ad4692_configure_channel(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+#if (ACTIVE_PLATFORM == STM32_PLATFORM)
+		ret = no_os_irq_clear_pending(trigger_irq_desc,
+					      trigger_gpio_irq_params.irq_ctrl_id);
+		if (ret) {
+			return ret;
+		}
+#endif
+		ret = iio_trig_enable(ad4692_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+
+		ret = ad4692_config_and_start_pwm(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Submit samples in CNV burst mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_cnv_burst_submit_samples(
+	struct iio_device_data *iio_dev_data)
+{
+	int ret;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+	uint32_t sample_index = 0;
+	uint32_t nb_of_samples;
+	ad4692_conversion_flag = false;
+	uint32_t data_read_local;
+	uint8_t i = 0;
+	uint8_t offset = 0;
+
+	if (!iio_dev_data) {
+		return -EINVAL;
+	}
+
+	nb_of_samples = iio_dev_data->buffer->size / n_data_bytes;
+
+	if (!buf_size_updated) {
+		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
+		buf_size_updated = true;
+	}
+
+	/* Start ADC data capture */
+	ret = ad4692_configure_channel(ad4692_dev);
+	if (ret) {
+		return ret;
+	}
+
+	/* Clear any pending interrupts */
+	ret = no_os_irq_clear_pending(trigger_irq_desc,
+				      trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	ret = no_os_irq_enable(trigger_irq_desc,
+			       trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	/* Config CNV PWM and start */
+	ret = ad4692_config_and_start_pwm(ad4692_dev);
+	if (ret) {
+		goto cbm_timer_trig_disable;
+	}
+
+	while (sample_index < nb_of_samples) {
+		/* Build the Tx Command */
+		ad4692_get_tx_command(acc_data_buff);
+
+		/* Check for status of conversion flag */
+		while (!ad4692_conversion_flag && timeout > 0) {
+			timeout--;
+		}
+
+		if (timeout == 0) {
+			ret = -ETIMEDOUT;
+			goto cbm_timer_trig_disable;
+		}
+		timeout = BUF_READ_TIMEOUT;
+
+		ad4692_conversion_flag = false;
+
+		ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
+					       num_of_active_channels * n_bytes_per_transaction);
+		if (ret) {
+			goto cbm_timer_trig_disable;
+		}
+
+		for (i = 0; i < num_of_active_channels; i++) {
+			offset = (i * n_bytes_per_transaction) + AD4692_N_BYTES_TXN_OFFSET;
+			if (ad4692_readback_option == ACCUMULATOR_DATA) {
+				data_read_local = no_os_get_unaligned_be24(&acc_data_buff[offset]);
+			} else {
+				data_read_local = no_os_get_unaligned_be16(&acc_data_buff[offset]);
+			}
+
+			ret = no_os_cb_write(iio_dev_data->buffer->buf,
+					     &data_read_local,
+					     n_data_bytes);
+			if (ret) {
+				goto cbm_timer_trig_disable;
+			}
+		}
+
+		/* Reset the state of accumulator */
+		ret = ad4692_reg_write(ad4692_dev,
+				       AD4692_STATE_RESET_REG,
+				       AD4692_STATE_RESET_ALL);
+		if (ret) {
+			goto cbm_timer_trig_disable;
+		}
+
+		sample_index += num_of_active_channels;
+	}
+
+cbm_timer_trig_disable:
+	/* Stop timer */
+	ad4692_stop_timer();
+
+	/* Disable triggers */
+	ret |= no_os_irq_disable(trigger_irq_desc,
+				 trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Trigger handler for CNV burst mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_cnv_burst_trigger_handler(
+	struct iio_device_data *iio_dev_data)
+{
+	int ret;
+	uint32_t data_read_local = 0;
+	uint8_t i;
+	uint8_t offset = 0;
+
+	/* Populate the Tx command */
+	ad4692_get_tx_command(acc_data_buff);
+
+	ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
+				       num_of_active_channels * n_bytes_per_transaction);
+	if (ret) {
+		return ret;
+	}
+
+	for (i = 0; i < num_of_active_channels; i++) {
+		offset = (i * n_bytes_per_transaction) + AD4692_N_BYTES_TXN_OFFSET;
+		if (ad4692_readback_option == ACCUMULATOR_DATA) {
+			data_read_local = no_os_get_unaligned_be24(&acc_data_buff[offset]);
+		} else {
+			data_read_local = no_os_get_unaligned_be16(&acc_data_buff[offset]);
+		}
+
+		ret = no_os_cb_write(iio_dev_data->buffer->buf,
+				     &data_read_local,
+				     n_data_bytes);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* Reset the state of accumulator */
+	ret = ad4692_reg_write(ad4692_dev,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief End data transfer in CNV burst mode
+ * @param dev[in] - IIO device instance
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_burst_end_transfer(void *dev)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ad4692_stop_timer();
+
+		ret = iio_trig_disable(ad4692_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	buf_size_updated = false;
+
+	return 0;
+}
+
+/**
+ * @brief Read single-shot ADC data in CNV burst mode
+ * @param desc[in] - AD4692 device descriptor
+ * @param chn[in] - Channel number
+ * @param adc_data[out] - ADC converted data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_burst_read_converted_data(struct ad4692_desc *desc,
+		uint8_t chn, uint32_t *adc_data)
+{
+	int ret;
+	uint8_t eoc_status;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+
+	ret = ad4692_configure_channel(desc);
+	if (ret) {
+		return ret;
+	}
+
+	/* Enable CNV PWM */
+	ret = no_os_pwm_enable(desc->conv_desc);
+	if (ret) {
+		return ret;
+	}
+
+	eoc_status = NO_OS_GPIO_HIGH;
+
+	/* Poll for DATA_READYb Low */
+	do {
+		ret = no_os_gpio_get_value(desc->gpio0_desc, &eoc_status);
+		if (ret) {
+			goto cbm_disable_cnv_pwm;
+		}
+	} while (eoc_status != NO_OS_GPIO_LOW && --timeout > 0);
+
+	if (timeout == 0) {
+		ret = -ETIMEDOUT;
+		goto cbm_disable_cnv_pwm;
+	}
+
+	ret = ad4692_reg_read(desc,
+			      AD4692_AVG_IN_REG(chn),
+			      adc_data);
+	if (ret) {
+		goto cbm_disable_cnv_pwm;
+	}
+	*adc_data = no_os_get_unaligned_be16((uint8_t *)adc_data);
+
+	/* Reset the state of accumulator */
+	ret = ad4692_reg_write(desc,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		goto cbm_disable_cnv_pwm;
+	}
+
+cbm_disable_cnv_pwm:
+	/* Disable CNV PWM */
+	ret |= no_os_pwm_disable(desc->conv_desc);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Update sampling frequency for CNV burst mode
+ * @param sampling_rate[in,out] - Requested/actual sampling rate
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_burst_update_sampling_frequency(
+	uint32_t *sampling_rate)
+{
+	int ret;
+	uint32_t period_ns_readback;
+
+	if (*sampling_rate > ad4692_sampling_frequency_max) {
+		*sampling_rate = ad4692_sampling_frequency_max;
+	}
+
+	ret = ad4692_configure_pwm_rate(ad4692_dev->conv_desc, *sampling_rate);
+	if (ret) {
+		return ret;
+	}
+
+	/* Get the actual period of the PWM */
+	ret = no_os_pwm_get_period(ad4692_dev->conv_desc, &period_ns_readback);
+	if (ret) {
+		return ret;
+	}
+
+	ad4692_sampling_frequency = PWM_PERIOD_TO_FREQUENCY(period_ns_readback);
+
+	return 0;
+}
+
+/**
+ * @brief Get maximum sampling rate for CNV burst mode
+ * @return Maximum sampling rate in samples per second
+ */
+static uint32_t ad4692_cnv_burst_get_max_sampling_rate(void)
+{
+	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
+		return (ad4692_readback_option == AVERAGED_DATA) ?
+		       S_RATE_CNV_BURST_STD_AVG : S_RATE_CNV_BURST_STD_ACC;
+	}
+
+	return (ad4692_readback_option == AVERAGED_DATA) ?
+	       S_RATE_CNV_BURST_ADV_AVG : S_RATE_CNV_BURST_ADV_ACC;
+}
+
+/* CNV burst mode data transfer system instance */
+struct ad4692_data_transfer_system ad4692_data_transfer_cnv_burst_mode = {
+	.initialize = ad4692_cnv_burst_init,
+	.prepare_transfer = ad4692_cnv_burst_prepare_transfer,
+	.submit_samples = ad4692_cnv_burst_submit_samples,
+	.trigger_handler = ad4692_cnv_burst_trigger_handler,
+	.end_transfer = ad4692_cnv_burst_end_transfer,
+	.remove = NULL,
+	.read_converted_data = ad4692_cnv_burst_read_converted_data,
+	.update_sampling_frequency = ad4692_cnv_burst_update_sampling_frequency,
+	.get_max_sampling_rate = ad4692_cnv_burst_get_max_sampling_rate,
+};

--- a/projects/ad4692_iio/app/ad4692_support_cnv_burst_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_cnv_burst_mode.c
@@ -3,7 +3,7 @@
  *   @brief   AD4692 CNV Burst Mode data transfer implementation
  *   @details Contains all data capture logic specific to CNV Burst Mode
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * By using this software you agree to the terms of the associated

--- a/projects/ad4692_iio/app/ad4692_support_cnv_clock_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_cnv_clock_mode.c
@@ -3,7 +3,7 @@
  *   @brief   AD4692 CNV Clock Mode data transfer implementation
  *   @details Contains all data capture logic specific to CNV Clock Mode
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * By using this software you agree to the terms of the associated

--- a/projects/ad4692_iio/app/ad4692_support_cnv_clock_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_cnv_clock_mode.c
@@ -1,0 +1,469 @@
+/***************************************************************************//**
+ *   @file    ad4692_support_cnv_clock_mode.c
+ *   @brief   AD4692 CNV Clock Mode data transfer implementation
+ *   @details Contains all data capture logic specific to CNV Clock Mode
+********************************************************************************
+ * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <string.h>
+
+#include "ad4692_support.h"
+#include "ad4692_iio.h"
+#include "ad4692_user_config.h"
+#include "no_os_error.h"
+#include "no_os_delay.h"
+#include "no_os_util.h"
+#include "app_config.h"
+#include "ad4692.h"
+#include "iio_trigger.h"
+
+/******************************************************************************/
+/************************ Macros/Constants ************************************/
+/******************************************************************************/
+
+#define BUF_READ_TIMEOUT	0xffffffff
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/* Maximum sampling frequency for CNV clock mode */
+static uint32_t ad4692_sampling_frequency_max;
+
+/* Accumulator data buffer */
+static uint8_t acc_data_buff[AD4692_N_BYTES_TXN_24BIT *
+						      AD4692_MAX_CHANNELS] = { 0x0 };
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static uint32_t ad4692_cnv_clock_get_max_sampling_rate(void);
+static int32_t ad4692_cnv_clock_update_sampling_frequency(
+	uint32_t *sampling_rate);
+
+/**
+ * @brief Initialize CNV clock mode
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_clock_data_capture_init(struct ad4692_desc *desc)
+{
+	int32_t ret;
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	ad4692_sampling_frequency_max = ad4692_cnv_clock_get_max_sampling_rate();
+
+	ret = ad4692_cnv_clock_update_sampling_frequency(
+		      &ad4692_sampling_frequency_max);
+	if (ret) {
+		return ret;
+	}
+
+	/* Reset manual mode bit */
+	ret = ad4692_reg_update(desc,
+				AD4692_DEVICE_SETUP_REG,
+				AD4692_MANUAL_MODE_MASK,
+				AD4692_EXIT_MANUAL_MODE);
+	if (ret) {
+		return ret;
+	}
+
+	/* Enter CNV Clock Mode */
+	ret = ad4692_reg_update(desc,
+				AD4692_ADC_SETUP_REG,
+				AD4692_MODE_MASK,
+				AD4692_CNV_CLOCK);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure GPIO0 as DATA_READYb */
+	ret = ad4692_reg_update(desc,
+				AD4692_GPIO_MODE1_REG,
+				AD4692_GPIO0_MASK,
+				AD4692_GPIO_OUTPUT_DATA_READYb);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Prepare for ADC data transfer in CNV clock mode
+ * @param dev[in] - IIO device instance
+ * @param ch_mask[in] - Channels select mask
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_clock_prepare_transfer(void *dev,
+		uint32_t ch_mask)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	ad4692_update_active_channels(ch_mask);
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ret = ad4692_configure_channel(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+#if (ACTIVE_PLATFORM == STM32_PLATFORM)
+		ret = no_os_irq_clear_pending(trigger_irq_desc,
+					      trigger_gpio_irq_params.irq_ctrl_id);
+		if (ret) {
+			return ret;
+		}
+#endif
+		ret = iio_trig_enable(ad4692_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+
+		ret = ad4692_config_and_start_pwm(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Submit samples in CNV clock mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_cnv_clock_submit_samples(
+	struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+	uint32_t sample_index = 0;
+	uint32_t nb_of_samples;
+	ad4692_conversion_flag = false;
+	uint32_t data_read_local;
+	uint8_t i;
+	uint8_t offset = 0;
+
+	if (!iio_dev_data) {
+		return -EINVAL;
+	}
+
+	nb_of_samples = iio_dev_data->buffer->size / n_data_bytes;
+
+	if (!buf_size_updated) {
+		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
+		buf_size_updated = true;
+	}
+
+	/* Start ADC data capture */
+	ret = ad4692_configure_channel(ad4692_dev);
+	if (ret) {
+		return ret;
+	}
+
+	/* Clear any pending interrupts */
+	ret = no_os_irq_clear_pending(trigger_irq_desc,
+				      trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	ret = no_os_irq_enable(trigger_irq_desc,
+			       trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	/* Config CNV PWM and start */
+	ret = ad4692_config_and_start_pwm(ad4692_dev);
+	if (ret) {
+		goto ccm_timer_trig_disable;
+	}
+
+	while (sample_index < nb_of_samples) {
+		/* Build the Tx Command */
+		ad4692_get_tx_command(acc_data_buff);
+
+		/* Check for status of conversion flag */
+		while (!ad4692_conversion_flag && timeout > 0) {
+			timeout--;
+		}
+
+		if (timeout == 0) {
+			ret = -ETIMEDOUT;
+			goto ccm_timer_trig_disable;
+		}
+		timeout = BUF_READ_TIMEOUT;
+
+		ad4692_conversion_flag = false;
+
+		ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
+					       num_of_active_channels * n_bytes_per_transaction);
+		if (ret) {
+			goto ccm_timer_trig_disable;
+		}
+
+		for (i = 0; i < num_of_active_channels; i++) {
+			offset = (i * n_bytes_per_transaction) + AD4692_N_BYTES_TXN_OFFSET;
+			if (ad4692_readback_option == ACCUMULATOR_DATA) {
+				data_read_local = no_os_get_unaligned_be24(&acc_data_buff[offset]);
+			} else {
+				data_read_local = no_os_get_unaligned_be16(&acc_data_buff[offset]);
+			}
+
+			ret = no_os_cb_write(iio_dev_data->buffer->buf,
+					     &data_read_local,
+					     n_data_bytes);
+			if (ret) {
+				goto ccm_timer_trig_disable;
+			}
+		}
+
+		/* Reset the state of accumulator */
+		ret = ad4692_reg_write(ad4692_dev,
+				       AD4692_STATE_RESET_REG,
+				       AD4692_STATE_RESET_ALL);
+		if (ret) {
+			goto ccm_timer_trig_disable;
+		}
+
+		sample_index += num_of_active_channels;
+	}
+
+ccm_timer_trig_disable:
+	/* Stop timer */
+	ad4692_stop_timer();
+
+	/* Disable triggers */
+	ret |= no_os_irq_disable(trigger_irq_desc,
+				 trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Trigger handler for CNV clock mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_cnv_clock_trigger_handler(
+	struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+	uint32_t data_read_local = 0;
+	uint8_t offset = 0;
+	uint8_t i;
+
+	/* Populate the Tx command */
+	ad4692_get_tx_command(acc_data_buff);
+
+	ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
+				       num_of_active_channels * n_bytes_per_transaction);
+	if (ret) {
+		return ret;
+	}
+
+	for (i = 0; i < num_of_active_channels; i++) {
+		offset = (i * n_bytes_per_transaction) + AD4692_N_BYTES_TXN_OFFSET;
+		if (ad4692_readback_option == ACCUMULATOR_DATA) {
+			data_read_local = no_os_get_unaligned_be24(&acc_data_buff[offset]);
+		} else {
+			data_read_local = no_os_get_unaligned_be16(&acc_data_buff[offset]);
+		}
+
+		ret = no_os_cb_write(iio_dev_data->buffer->buf,
+				     &data_read_local,
+				     n_data_bytes);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* Reset the state of accumulator */
+	ret = ad4692_reg_write(ad4692_dev,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief End data transfer in CNV clock mode
+ * @param dev[in] - IIO device instance
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_clock_end_transfer(void *dev)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ad4692_stop_timer();
+
+		ret = iio_trig_disable(ad4692_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	buf_size_updated = false;
+
+	return 0;
+}
+
+/**
+ * @brief Read single-shot ADC data in CNV clock mode
+ * @param desc[in] - AD4692 device descriptor
+ * @param chn[in] - Channel number
+ * @param adc_data[out] - ADC converted data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_clock_read_converted_data(struct ad4692_desc *desc,
+		uint8_t chn, uint32_t *adc_data)
+{
+	int32_t ret;
+	uint8_t eoc_status;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+
+	ret = ad4692_configure_channel(desc);
+	if (ret) {
+		return ret;
+	}
+
+	/* Enable CNV PWM */
+	ret = no_os_pwm_enable(desc->conv_desc);
+	if (ret) {
+		return ret;
+	}
+
+	eoc_status = NO_OS_GPIO_HIGH;
+
+	/* Poll for DATA_READYb Low */
+	do {
+		ret = no_os_gpio_get_value(desc->gpio0_desc, &eoc_status);
+		if (ret) {
+			goto ccm_disable_cnv_pwm;
+		}
+	} while (eoc_status != NO_OS_GPIO_LOW && --timeout > 0);
+
+	if (timeout == 0) {
+		ret = -ETIMEDOUT;
+		goto ccm_disable_cnv_pwm;
+	}
+
+	ret = ad4692_reg_read(desc,
+			      AD4692_AVG_IN_REG(chn),
+			      adc_data);
+	if (ret) {
+		goto ccm_disable_cnv_pwm;
+	}
+	*adc_data = no_os_get_unaligned_be16((uint8_t *)adc_data);
+
+	/* Reset the state of accumulator to start a new burst of conversion */
+	ret = ad4692_reg_write(desc,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		goto ccm_disable_cnv_pwm;
+	}
+
+ccm_disable_cnv_pwm:
+	/* Disable CNV PWM */
+	ret |= no_os_pwm_disable(desc->conv_desc);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Update sampling frequency for CNV clock mode
+ * @param sampling_rate[in,out] - Requested/actual sampling rate
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_cnv_clock_update_sampling_frequency(
+	uint32_t *sampling_rate)
+{
+	int32_t ret;
+	uint32_t period_ns_readback;
+
+	if (*sampling_rate > ad4692_sampling_frequency_max) {
+		*sampling_rate = ad4692_sampling_frequency_max;
+	}
+
+	ret = ad4692_configure_pwm_rate(ad4692_dev->conv_desc, *sampling_rate);
+	if (ret) {
+		return ret;
+	}
+
+	/* Get the actual period of the PWM */
+	ret = no_os_pwm_get_period(ad4692_dev->conv_desc, &period_ns_readback);
+	if (ret) {
+		return ret;
+	}
+
+	ad4692_sampling_frequency = PWM_PERIOD_TO_FREQUENCY(period_ns_readback);
+
+	return 0;
+}
+
+/**
+ * @brief Get maximum sampling rate for CNV clock mode
+ * @return Maximum sampling rate in samples per second
+ */
+static uint32_t ad4692_cnv_clock_get_max_sampling_rate(void)
+{
+	if (ad4692_readback_option == AVERAGED_DATA) {
+		return (ad4692_sequencer_mode == STANDARD_SEQUENCER) ?
+		       S_RATE_CNV_CLOCK_INTR_STD_AVG :
+		       S_RATE_CNV_CLOCK_INTR_ADV_AVG;
+	}
+
+	return (ad4692_sequencer_mode == STANDARD_SEQUENCER) ?
+	       S_RATE_CNV_CLOCK_INTR_STD_ACC :
+	       S_RATE_CNV_CLOCK_INTR_ADV_ACC;
+}
+
+/* CNV clock mode data transfer system instance */
+struct ad4692_data_transfer_system ad4692_data_transfer_cnv_clock_mode = {
+	.initialize = ad4692_cnv_clock_data_capture_init,
+	.prepare_transfer = ad4692_cnv_clock_prepare_transfer,
+	.submit_samples = ad4692_cnv_clock_submit_samples,
+	.trigger_handler = ad4692_cnv_clock_trigger_handler,
+	.end_transfer = ad4692_cnv_clock_end_transfer,
+	.remove = NULL,
+	.read_converted_data = ad4692_cnv_clock_read_converted_data,
+	.update_sampling_frequency = ad4692_cnv_clock_update_sampling_frequency,
+	.get_max_sampling_rate = ad4692_cnv_clock_get_max_sampling_rate,
+};

--- a/projects/ad4692_iio/app/ad4692_support_manual_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_manual_mode.c
@@ -1,0 +1,955 @@
+/***************************************************************************//**
+ *   @file    ad4692_support_manual_mode.c
+ *   @brief   AD4692 Manual Mode data transfer implementation
+ *   @details Contains all data capture logic specific to Manual Mode
+********************************************************************************
+ * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <string.h>
+
+#include "ad4692_support.h"
+#include "ad4692_iio.h"
+#include "ad4692_user_config.h"
+#include "no_os_error.h"
+#include "no_os_delay.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+#include "app_config.h"
+#include "ad4692.h"
+#include "iio_trigger.h"
+
+/******************************************************************************/
+/************************ Macros/Constants ************************************/
+/******************************************************************************/
+
+/* Timeout count to avoid stuck into potential infinite loop */
+#define BUF_READ_TIMEOUT	0xffffffff
+
+/* Maximum value the DMA NDTR register can take */
+#define MAX_LOCAL_BUF_SIZE	65536
+#define MAX_DMA_NDTR		(no_os_min(65532, (MAX_LOCAL_BUF_SIZE)))
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/* SPI message for manual mode capture */
+static struct no_os_spi_msg ad4692_spi_msg_manual_mode = {
+	.cs_change = CS_CHANGE,
+	.tx_buff = NULL,
+	.rx_buff = NULL,
+	.bytes_number = BYTES_PER_SAMPLE
+};
+
+/* Data buffer for SPI transactions */
+static uint8_t data_buff[BYTES_PER_SAMPLE] = { 0x0 };
+
+/* Flag to indicate if DMA has been configured for capture */
+static volatile bool dma_config_updated = false;
+
+/* Flag for checking DMA buffer overflow */
+volatile bool ad4692_dma_buff_full = false;
+
+/* Variable to store start of buffer address */
+volatile uint32_t *buff_start_addr;
+
+/* Local buffer for DMA */
+__attribute__((aligned(32))) static uint8_t local_buf[MAX_LOCAL_BUF_SIZE +
+				   (NO_OF_CHANNELS * N_CYCLE_OFFSET)];
+
+/* Variable to track the number of entries to the complete callback */
+uint32_t callback_count = 0;
+
+/* Global Pointer for IIO Device Data (used by DMA callbacks) */
+volatile struct iio_device_data *iio_dev_data_g;
+
+/* Global variable for number of samples (used by DMA callbacks) */
+uint32_t nb_of_samples_g;
+
+/* Channel ID during data capture */
+static volatile uint8_t chan_id = 0;
+
+/* Chip Select GPIO init parameters */
+static struct no_os_gpio_init_param csb_gpio_init_param = {
+	.port = SPI_CS_PORT_NUM,
+	.number = SPI_CSB,
+	.pull = NO_OS_PULL_NONE,
+	.platform_ops = &gpio_ops,
+	.extra = &gpio_output_extra_init_params
+};
+
+/* CNV GPIO Init params */
+static struct no_os_gpio_init_param cnv_gpio_init_param = {
+	.port = CNV_PORT_NUM,
+	.number = CNV_PIN_NUM,
+	.platform_ops = &gpio_ops,
+	.extra = &gpio_input_extra_init_params
+};
+
+/* Tx Trigger Init params */
+static struct no_os_pwm_init_param tx_trigger_init_param = {
+	.id = TX_TRIGGER_TIMER_ID,
+	.period_ns = TX_TRIGGER_PERIOD,
+	.duty_cycle_ns = TX_TRIGGER_DUTY_RATIO,
+	.polarity = NO_OS_PWM_POLARITY_HIGH,
+	.platform_ops = &pwm_ops,
+	.extra = &tx_trigger_extra_init_params,
+};
+
+/* Tx trigger descriptor */
+static struct no_os_pwm_desc *tx_trigger_desc = NULL;
+
+/* CNV GPIO descriptor */
+static struct no_os_gpio_desc *cnv_gpio_desc = NULL;
+
+/* Chip Select GPIO descriptor */
+static struct no_os_gpio_desc *csb_gpio_desc = NULL;
+
+/* Maximum sampling frequency for manual mode */
+static uint32_t ad4692_sampling_frequency_max;
+
+/* DMA NDTR register value */
+extern uint32_t rxdma_ndtr;
+
+/* DMA cycle count */
+extern uint32_t dma_cycle_count;
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static uint32_t ad4692_manual_get_max_sampling_rate(void);
+static int32_t ad4692_manual_update_sampling_frequency(uint32_t *sampling_rate);
+static int32_t ad4692_stop_data_capture(struct ad4692_desc *desc);
+
+/**
+ * @brief Reconfigure CNV GPIO as PWM or GPIO based on the mode
+ *
+ * @param gpio_cnv[in, out] - GPIO descriptor for CNV, which will be reconfigured as PWM or GPIO
+ * @param pwm_gpio[in] - boolean flag to indicate if CNV is to be configured as PWM (true) or GPIO (false)
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t ad4692_reconfigure_cnv(struct no_os_gpio_desc **gpio_cnv,
+				      bool pwm_gpio)
+{
+	int32_t ret;
+
+	if (!gpio_cnv) {
+		return -EINVAL;
+	}
+
+	/* Remove existing GPIO descriptor (if any) */
+	if (*gpio_cnv) {
+		NO_OS_UNUSED_PARAM(no_os_gpio_remove(*gpio_cnv));
+		*gpio_cnv = NULL;
+	}
+
+	if (pwm_gpio) {
+		/* Configure CNV as PWM */
+		ret = no_os_gpio_get(gpio_cnv, &cnv_pwm_gpio_params);
+		if (ret) {
+			return ret;
+		}
+	} else {
+		/* Configure CNV as GPIO */
+		ret = no_os_gpio_get(gpio_cnv, &cnv_gpio_init_param);
+		if (ret) {
+			return ret;
+		}
+
+		ret = no_os_gpio_direction_output(*gpio_cnv, NO_OS_GPIO_LOW);
+		if (ret) {
+			NO_OS_UNUSED_PARAM(no_os_gpio_remove(*gpio_cnv));
+			*gpio_cnv = NULL;
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Toggle CNV GPIO
+ * @param gpio_cnv[in, out] - GPIO CNV Descriptor
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t ad4692_toggle_cnv(struct no_os_gpio_desc *gpio_cnv)
+{
+	int32_t ret;
+
+	if (!gpio_cnv) {
+		return -EINVAL;
+	}
+
+	ret = no_os_gpio_set_value(gpio_cnv, NO_OS_GPIO_HIGH);
+	if (ret) {
+		return ret;
+	}
+
+	no_os_udelay(1);
+
+	ret = no_os_gpio_set_value(gpio_cnv, NO_OS_GPIO_LOW);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Initialize device for data capture in manual mode
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_start_data_capture(struct ad4692_desc *desc)
+{
+	int32_t ret;
+	uint8_t toggle_n;
+	struct no_os_spi_msg ad4692_spi_msg = {
+		.cs_change = CS_CHANGE,
+		.tx_buff = data_buff,
+		.rx_buff = data_buff,
+		.bytes_number = BYTES_PER_SAMPLE
+	};
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	if (ad4692_interface_mode == SPI_DMA) {
+		ret = no_os_gpio_get(&csb_gpio_desc, &csb_gpio_init_param);
+		if (ret) {
+			return ret;
+		}
+
+		ret = no_os_gpio_direction_output(csb_gpio_desc, NO_OS_GPIO_LOW);
+		if (ret) {
+			goto mm_stop_data_capture;
+		}
+	}
+
+	/* Enter Manual Mode */
+	ret = ad4692_reg_write(desc,
+			       AD4692_DEVICE_SETUP_REG,
+			       AD4692_DEVICE_MANUAL);
+	if (ret) {
+		goto mm_stop_data_capture;
+	}
+
+	/* Skip 2 samples at the beginning of manual mode as the data is 2 sample delayed */
+	if (ad4692_interface_mode != SPI_DMA) {
+		ret = ad4692_reconfigure_cnv(&cnv_gpio_desc, false);
+		if (ret) {
+			goto mm_stop_data_capture;
+		}
+
+		/* Toggle CNV at a gap of 5us */
+		for (toggle_n = 0; toggle_n < AD4692_N_CNV_TOGGLES; toggle_n++) {
+			no_os_udelay(5);
+			ret = ad4692_toggle_cnv(cnv_gpio_desc);
+			if (ret) {
+				goto mm_stop_data_capture;
+			}
+
+			/* Register the channel ID */
+			data_buff[0] = AD4692_IN_COMMAND(ad4692_active_channels[chan_id]);
+			data_buff[1] = 0x0;
+
+			if (num_of_active_channels > 1) {
+				chan_id++;
+			}
+
+			ret = no_os_spi_transfer(desc->comm_desc, &ad4692_spi_msg, 1);
+			if (ret) {
+				goto mm_stop_data_capture;
+			}
+		}
+
+		ret = ad4692_reconfigure_cnv(&cnv_gpio_desc, true);
+		if (ret) {
+			goto mm_stop_data_capture;
+		}
+	}
+
+	return 0;
+mm_stop_data_capture:
+	NO_OS_UNUSED_PARAM(ad4692_stop_data_capture(desc));
+	return ret;
+}
+
+/**
+ * @brief Stop data capture in manual mode
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_stop_data_capture(struct ad4692_desc *desc)
+{
+	int32_t ret;
+	uint8_t toggle_n;
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	ret = ad4692_reconfigure_cnv(&cnv_gpio_desc, false);
+	if (ret) {
+		return ret;
+	}
+
+	/* Toggle CNV at a gap of 5us */
+	for (toggle_n = 0; toggle_n < AD4692_N_CNV_TOGGLES; toggle_n++) {
+		no_os_udelay(5);
+		ret = ad4692_toggle_cnv(cnv_gpio_desc);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	ret = ad4692_reconfigure_cnv(&cnv_gpio_desc, true);
+	if (ret) {
+		return ret;
+	}
+
+	ret = ad4692_exit_manual_mode(desc);
+	if (ret) {
+		return ret;
+	}
+
+	if (cnv_gpio_desc) {
+		NO_OS_UNUSED_PARAM(no_os_gpio_remove(cnv_gpio_desc));
+		cnv_gpio_desc = NULL;
+	}
+
+	if (csb_gpio_desc) {
+		NO_OS_UNUSED_PARAM(no_os_gpio_remove(csb_gpio_desc));
+		csb_gpio_desc = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Read data in burst mode via SPI DMA
+ * @param nb_of_samples_req[in] - Number of samples requested by IIO
+ * @param iio_dev_data[in] - IIO Device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_read_data_spi_dma(uint32_t nb_of_samples_req,
+					struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+	uint32_t spirxdma_ndtr;
+	uint32_t data_read;
+	static uint8_t local_tx_data[32] = { 0x0 };
+
+	if (ad4692_data_capture_mode == BURST_DATA_CAPTURE) {
+		nb_of_samples_req = nb_of_samples_req * BYTES_PER_SAMPLE;
+
+		ret = no_os_cb_prepare_async_write(iio_dev_data->buffer->buf,
+						   nb_of_samples_req,
+						   (void **) &buff_start_addr,
+						   &data_read);
+		if (ret) {
+			return ret;
+		}
+
+		/* Manipulate the number of samples considering the 2-cycle offset */
+		if (num_of_active_channels <= 2) {
+			nb_of_samples_req += (N_CYCLE_OFFSET * BYTES_PER_SAMPLE);
+		} else {
+			nb_of_samples_req += (num_of_active_channels * BYTES_PER_SAMPLE);
+		}
+
+		if (!dma_config_updated) {
+			/* Build the Tx command with respect to the enabled channels */
+			ad4692_get_tx_command(local_tx_data);
+
+			/* Cap SPI RX DMA NDTR to MAX_DMA_NDTR */
+			spirxdma_ndtr = no_os_min(MAX_DMA_NDTR, nb_of_samples_req);
+			rxdma_ndtr = spirxdma_ndtr;
+
+			/* Register half complete callback */
+			HAL_DMA_RegisterCallback(&hdma_spi1_rx,
+						 HAL_DMA_XFER_HALFCPLT_CB_ID,
+						 ad4692_spi_dma_rx_half_cplt_callback);
+
+			struct no_os_spi_msg  ad4692_spi_msg = {
+				.tx_buff = local_tx_data,
+				.rx_buff = local_buf,
+				.bytes_number = spirxdma_ndtr,
+			};
+
+			ret = no_os_spi_transfer_dma_async(ad4692_dev->comm_desc,
+							   &ad4692_spi_msg,
+							   1, NULL, NULL);
+			if (ret) {
+				return ret;
+			}
+
+			/* DMA to be disabled while reconfiguring the NDTR register */
+			DMA2_Stream2->CR &= ~1;
+			DMA2_Stream2->NDTR = num_of_active_channels * 2;
+			DMA2_Stream2->CR |= 1;
+
+			dma_config_updated = true;
+		}
+
+		if (nb_of_samples_req == rxdma_ndtr) {
+			dma_cycle_count = 1;
+		} else {
+			dma_cycle_count = ((nb_of_samples_req) / rxdma_ndtr) + 1;
+		}
+		callback_count = dma_cycle_count * 2;
+		update_buff(local_buf, (uint8_t *)buff_start_addr);
+
+		/* Configure CNV PWM and start */
+		ret = ad4692_config_and_start_pwm(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+
+		while (ad4692_dma_buff_full != true && timeout > 0) {
+			timeout--;
+		}
+
+		if (!timeout) {
+			return -EIO;
+		}
+
+		ad4692_dma_buff_full = false;
+		ret = no_os_cb_end_async_write(iio_dev_data->buffer->buf);
+		if (ret) {
+			return ret;
+		}
+		ad4692_stop_timer();
+	} else { // CONTINUOUS_DATA_CAPTURE
+		if (!dma_config_updated) {
+			/* Build the Tx command with respect to the enabled channels */
+			ad4692_get_tx_command(local_tx_data);
+
+			nb_of_samples_req = nb_of_samples_req * BYTES_PER_SAMPLE;
+
+			/* Manipulate the number of samples considering the 2-cycle offset */
+			if (num_of_active_channels <= 2) {
+				nb_of_samples_req += (N_CYCLE_OFFSET * BYTES_PER_SAMPLE);
+			} else {
+				nb_of_samples_req += (num_of_active_channels * BYTES_PER_SAMPLE);
+			}
+
+			spirxdma_ndtr = no_os_min(MAX_DMA_NDTR, nb_of_samples_req);
+			rxdma_ndtr = spirxdma_ndtr;
+
+			nb_of_samples_g = spirxdma_ndtr;
+			iio_dev_data_g = iio_dev_data;
+
+			/* SPI Message */
+			struct no_os_spi_msg ad4692_spi_msg = {
+				.tx_buff = local_tx_data,
+				.rx_buff = local_buf,
+				.bytes_number = spirxdma_ndtr
+			};
+
+			ret = no_os_cb_prepare_async_write(iio_dev_data_g->buffer->buf,
+							   nb_of_samples_req,
+							   (void **) &buff_start_addr,
+							   &data_read);
+			if (ret) {
+				return ret;
+			}
+
+			ret = no_os_spi_transfer_dma_async(ad4692_dev->comm_desc,
+							   &ad4692_spi_msg, 1,
+							   NULL, NULL);
+			if (ret) {
+				return ret;
+			}
+
+			/* DMA to be disabled while configuring the NDTR Register */
+			DMA2_Stream2->CR &= ~1;
+			DMA2_Stream2->NDTR = num_of_active_channels * BYTES_PER_SAMPLE;
+			DMA2_Stream2->CR |= 1;
+
+			dma_config_updated = true;
+
+			/* Update Buffer indices */
+			update_buff(local_buf, (uint8_t *)buff_start_addr);
+
+			/* Configure CNV PWM and start */
+			ret = ad4692_config_and_start_pwm(ad4692_dev);
+			if (ret) {
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Initialize manual mode
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_manual_init(struct ad4692_desc *desc)
+{
+	int32_t ret;
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	ad4692_sampling_frequency_max = ad4692_manual_get_max_sampling_rate();
+
+	ret = ad4692_manual_update_sampling_frequency(&ad4692_sampling_frequency_max);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure GPIO0 as BUSY */
+	ret = ad4692_gpio_set(desc,
+			      AD4692_GPIO0,
+			      AD4692_GPIO_OUTPUT_ADC_BUSY);
+	if (ret) {
+		return ret;
+	}
+
+	if (ad4692_interface_mode == SPI_DMA) {
+		ret = no_os_pwm_init(&tx_trigger_desc, &tx_trigger_init_param);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Prepare for ADC data transfer in manual mode
+ * @param dev[in] - IIO device instance
+ * @param ch_mask[in] - Channels select mask
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_manual_prepare_transfer(void *dev,
+		uint32_t ch_mask)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	chan_id = 0;
+	ad4692_update_active_channels(ch_mask);
+
+	if ((ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE)
+	    || (ad4692_interface_mode == SPI_DMA)) {
+		/* Start ADC Data capture */
+		ret = ad4692_start_data_capture(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	if (ad4692_interface_mode == SPI_INTR) {
+		if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+#if (ACTIVE_PLATFORM == STM32_PLATFORM)
+			ret = no_os_irq_clear_pending(trigger_irq_desc,
+						      trigger_gpio_irq_params.irq_ctrl_id);
+			if (ret) {
+				return ret;
+			}
+#endif
+			ret = iio_trig_enable(ad4692_hw_trig_desc);
+			if (ret) {
+				return ret;
+			}
+
+			/* Configure CNV PWM and start */
+			ret = ad4692_config_and_start_pwm(ad4692_dev);
+			if (ret) {
+				return ret;
+			}
+		}
+	} else { // SPI DMA
+		/* Pull the SPI CS line low to enable the data on SDO */
+		ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_LOW);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Submit samples in manual mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_manual_submit_samples(struct iio_device_data
+		*iio_dev_data)
+{
+	int32_t ret;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+	uint32_t sample_index = 0;
+	uint32_t nb_of_samples;
+	ad4692_conversion_flag = false;
+	uint8_t ch = 0;
+
+	if (!iio_dev_data) {
+		return -EINVAL;
+	}
+
+	nb_of_samples = iio_dev_data->buffer->size / n_data_bytes;
+
+	if (!buf_size_updated) {
+		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
+		buf_size_updated = true;
+	}
+
+	if (ad4692_interface_mode == SPI_INTR) {
+		/* Start ADC data capture */
+		ret = ad4692_start_data_capture(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+
+		/* Clear any pending interrupts */
+		ret = no_os_irq_clear_pending(trigger_irq_desc,
+					      trigger_gpio_irq_params.irq_ctrl_id);
+		if (ret) {
+			goto mm_submit_samples_exit;
+		}
+
+		ret = no_os_irq_enable(trigger_irq_desc,
+				       trigger_gpio_irq_params.irq_ctrl_id);
+		if (ret) {
+			goto mm_submit_samples_exit;
+		}
+
+		/* Config CNV PWM and start */
+		ret = ad4692_config_and_start_pwm(ad4692_dev);
+		if (ret) {
+			goto mm_submit_samples_exit;
+		}
+
+		while (sample_index < nb_of_samples) {
+			/* Check for status of conversion flag */
+			while (!ad4692_conversion_flag && timeout > 0) {
+				timeout--;
+			}
+
+			if (timeout == 0) {
+				ret = -ETIMEDOUT;
+				goto mm_submit_samples_exit;
+			}
+			timeout = BUF_READ_TIMEOUT;
+
+			ad4692_conversion_flag = false;
+
+			/* Reset the channel ID back to the first enabled channel */
+			if (ch >= num_of_active_channels) {
+				ch = 0;
+			}
+
+			data_buff[0] = AD4692_IN_COMMAND(ad4692_active_channels[ch++]);
+			data_buff[1] = 0x0;
+
+			ad4692_spi_msg_manual_mode.tx_buff = data_buff;
+			ad4692_spi_msg_manual_mode.rx_buff = data_buff;
+
+			ret = no_os_spi_transfer(ad4692_dev->comm_desc,
+						 &ad4692_spi_msg_manual_mode, 1);
+			if (ret) {
+				goto mm_submit_samples_exit;
+			}
+
+			ret = no_os_cb_write(iio_dev_data->buffer->buf,
+					     ad4692_spi_msg_manual_mode.rx_buff,
+					     n_data_bytes);
+			if (ret) {
+				goto mm_submit_samples_exit;
+			}
+
+			sample_index++;
+		}
+
+mm_submit_samples_exit:
+		/* Stop timer */
+		ad4692_stop_timer();
+
+		/* Disable triggers */
+		ret |= no_os_irq_disable(trigger_irq_desc,
+					 trigger_gpio_irq_params.irq_ctrl_id);
+
+		/* Stop ADC Data capture */
+		ret |= ad4692_stop_data_capture(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	} else { // SPI_DMA
+		ret = ad4692_read_data_spi_dma(nb_of_samples, iio_dev_data);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Trigger handler for manual mode (continuous capture via ISR)
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_manual_trigger_handler(
+	struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+
+	/* Reset the channel ID back to the first enabled channel */
+	if (chan_id >= num_of_active_channels) {
+		chan_id = 0;
+	}
+
+	data_buff[0] = AD4692_IN_COMMAND(ad4692_active_channels[chan_id++]);
+	data_buff[1] = 0x0;
+
+	ad4692_spi_msg_manual_mode.tx_buff = data_buff;
+	ad4692_spi_msg_manual_mode.rx_buff = data_buff;
+
+	ret = no_os_spi_transfer(ad4692_dev->comm_desc,
+				 &ad4692_spi_msg_manual_mode, 1);
+	if (ret) {
+		return ret;
+	}
+
+	ret = no_os_cb_write(iio_dev_data->buffer->buf,
+			     ad4692_spi_msg_manual_mode.rx_buff,
+			     n_data_bytes);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief End data transfer in manual mode
+ * @param dev[in] - IIO device instance
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_manual_end_transfer(void *dev)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	if (ad4692_interface_mode == SPI_INTR) {
+		if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+			/* Stop timer */
+			ad4692_stop_timer();
+
+			/* Disable triggers */
+			ret = iio_trig_disable(ad4692_hw_trig_desc);
+			if (ret) {
+				return ret;
+			}
+		}
+	} else { // SPI_DMA
+		/* Stop timers */
+		ad4692_stop_timer();
+
+		stm32_abort_dma_transfer();
+
+		/* Pull the SPI CS line back high to enable reg Access */
+		ret = no_os_gpio_set_value(csb_gpio_desc, NO_OS_GPIO_HIGH);
+		if (ret) {
+			return ret;
+		}
+
+		/* De initialize the Tx Trigger PWM */
+		ret = no_os_pwm_disable(tx_trigger_desc);
+		if (ret) {
+			return ret;
+		}
+
+		dma_config_updated = false;
+	}
+
+	/* Stop ADC Data capture */
+	ret = ad4692_stop_data_capture(ad4692_dev);
+	if (ret) {
+		return ret;
+	}
+
+	buf_size_updated = false;
+
+	return 0;
+}
+
+/**
+ * @brief Remove manual mode resources
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success
+ */
+static int32_t ad4692_manual_remove(struct ad4692_desc *desc)
+{
+	if (tx_trigger_desc) {
+		no_os_pwm_remove(tx_trigger_desc);
+		tx_trigger_desc = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Read single-shot ADC data in manual mode
+ * @param desc[in] - AD4692 device descriptor
+ * @param chn[in] - Channel number
+ * @param adc_data[out] - ADC converted data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_manual_read_converted_data(struct ad4692_desc *desc,
+		uint8_t chn, uint32_t *adc_data)
+{
+	int32_t ret;
+	uint8_t eoc_status;
+	uint8_t toggle_n;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+
+	ret = ad4692_start_data_capture(desc);
+	if (ret) {
+		return ret;
+	}
+
+	data_buff[0] = AD4692_IN_COMMAND(chn);
+	data_buff[1] = 0x0;
+	eoc_status = NO_OS_GPIO_HIGH;
+
+	ret = no_os_gpio_direction_input(desc->gpio0_desc);
+	if (ret) {
+		goto mm_stop_read_converted_data;
+	}
+
+	ret = ad4692_reconfigure_cnv(&cnv_gpio_desc, false);
+	if (ret) {
+		goto mm_stop_read_converted_data;
+	}
+
+	/* Toggle CNV to skip the initial dummy data */
+	for (toggle_n = 0; toggle_n <= AD4692_N_CNV_TOGGLES; toggle_n++) {
+		timeout = BUF_READ_TIMEOUT;
+
+		ret = ad4692_toggle_cnv(cnv_gpio_desc);
+		if (ret) {
+			goto mm_stop_read_converted_data;
+		}
+
+		/* Poll for BSY Low */
+		do {
+			ret = no_os_gpio_get_value(desc->gpio0_desc, &eoc_status);
+			if (ret) {
+				goto mm_stop_read_converted_data;
+			}
+		} while ((eoc_status != NO_OS_GPIO_LOW) && (--timeout > 0));
+
+		if (timeout == 0) {
+			ret = -ETIMEDOUT;
+			goto mm_stop_read_converted_data;
+		}
+	}
+
+	ret = ad4692_reconfigure_cnv(&cnv_gpio_desc, true);
+	if (ret) {
+		goto mm_stop_read_converted_data;
+	}
+
+	ad4692_spi_msg_manual_mode.tx_buff = data_buff;
+	ad4692_spi_msg_manual_mode.rx_buff = data_buff;
+
+	ret = no_os_spi_transfer(desc->comm_desc, &ad4692_spi_msg_manual_mode,
+				 1);
+	if (ret) {
+		goto mm_stop_read_converted_data;
+	}
+
+	*adc_data = no_os_get_unaligned_be16(ad4692_spi_msg_manual_mode.rx_buff);
+
+mm_stop_read_converted_data:
+	/* Stop data capture after single-shot read */
+	ret |= ad4692_stop_data_capture(desc);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Update sampling frequency for manual mode
+ * @param sampling_rate[in,out] - Requested/actual sampling rate
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_manual_update_sampling_frequency(uint32_t *sampling_rate)
+{
+	int32_t ret;
+	uint32_t period_ns_readback;
+
+	if (*sampling_rate > ad4692_sampling_frequency_max) {
+		*sampling_rate = ad4692_sampling_frequency_max;
+	}
+
+	ret = ad4692_configure_pwm_rate(ad4692_dev->conv_desc, *sampling_rate);
+	if (ret) {
+		return ret;
+	}
+
+	/* Get the actual period of the PWM */
+	ret = no_os_pwm_get_period(ad4692_dev->conv_desc, &period_ns_readback);
+	if (ret) {
+		return ret;
+	}
+
+	ad4692_sampling_frequency = PWM_PERIOD_TO_FREQUENCY(period_ns_readback);
+
+	return 0;
+}
+
+/**
+ * @brief Get maximum sampling rate for manual mode
+ * @return Maximum sampling rate in samples per second
+ */
+static uint32_t ad4692_manual_get_max_sampling_rate(void)
+{
+	if (ad4692_interface_mode == SPI_DMA) {
+		return S_RATE_MANUAL_DMA;
+	}
+
+	return S_RATE_MANUAL_INTR;
+}
+
+/* Manual mode data transfer system instance */
+struct ad4692_data_transfer_system ad4692_data_transfer_manual_mode = {
+	.initialize = ad4692_manual_init,
+	.prepare_transfer = ad4692_manual_prepare_transfer,
+	.submit_samples = ad4692_manual_submit_samples,
+	.trigger_handler = ad4692_manual_trigger_handler,
+	.end_transfer = ad4692_manual_end_transfer,
+	.remove = ad4692_manual_remove,
+	.read_converted_data = ad4692_manual_read_converted_data,
+	.update_sampling_frequency = ad4692_manual_update_sampling_frequency,
+	.get_max_sampling_rate = ad4692_manual_get_max_sampling_rate,
+};

--- a/projects/ad4692_iio/app/ad4692_support_manual_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_manual_mode.c
@@ -3,7 +3,7 @@
  *   @brief   AD4692 Manual Mode data transfer implementation
  *   @details Contains all data capture logic specific to Manual Mode
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * By using this software you agree to the terms of the associated

--- a/projects/ad4692_iio/app/ad4692_support_spi_burst_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_spi_burst_mode.c
@@ -1,0 +1,520 @@
+/***************************************************************************//**
+ *   @file    ad4692_support_spi_burst_mode.c
+ *   @brief   AD4692 SPI Burst Mode data transfer implementation
+ *   @details Contains all data capture logic specific to SPI Burst Mode
+********************************************************************************
+ * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ *
+ * This software is proprietary to Analog Devices, Inc. and its licensors.
+ * By using this software you agree to the terms of the associated
+ * Analog Devices Software License Agreement.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <string.h>
+
+#include "ad4692_support.h"
+#include "ad4692_iio.h"
+#include "ad4692_user_config.h"
+#include "no_os_error.h"
+#include "no_os_delay.h"
+#include "no_os_util.h"
+#include "app_config.h"
+#include "ad4692.h"
+#include "iio_trigger.h"
+
+/******************************************************************************/
+/************************ Macros/Constants ************************************/
+/******************************************************************************/
+
+#define BUF_READ_TIMEOUT	0xffffffff
+
+/* Stop State mask */
+#define AD4692_ADC_MODE_STOP_STATE_MASK  NO_OS_BIT(5)
+
+/* Data Ready Stop state */
+#define AD4692_STOP_STATE_DATA_READYb   0x1
+
+/* Number of bytes per transaction for accumulator data */
+#define AD4692_N_BYTES_SPI_BURST_24BIT	5
+
+/* Number of bytes per transaction for averaged data */
+#define AD4692_N_BYTES_SPI_BURST_16BIT	4
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/* Maximum sampling frequency for SPI burst mode */
+static uint32_t ad4692_sampling_frequency_max;
+
+/* Accumulator data buffer */
+static uint8_t acc_data_buff[AD4692_N_BYTES_SPI_BURST_24BIT *
+							    AD4692_MAX_CHANNELS] = { 0x0 };
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static uint32_t ad4692_spi_burst_get_max_sampling_rate(void);
+static int32_t ad4692_spi_burst_update_sampling_frequency(
+	uint32_t *sampling_rate);
+
+/**
+ * @brief Initialize SPI burst mode
+ * @param desc[in] - AD4692 device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_spi_burst_init(struct ad4692_desc *desc)
+{
+	int32_t ret;
+
+	if (!desc) {
+		return -EINVAL;
+	}
+
+	ad4692_sampling_frequency_max = ad4692_spi_burst_get_max_sampling_rate();
+
+	ret = ad4692_spi_burst_update_sampling_frequency(
+		      &ad4692_sampling_frequency_max);
+	if (ret) {
+		return ret;
+	}
+
+	/* Reset manual mode bit */
+	ret = ad4692_reg_update(desc,
+				AD4692_DEVICE_SETUP_REG,
+				AD4692_MANUAL_MODE_MASK,
+				AD4692_EXIT_MANUAL_MODE);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure GPIO0 as DATA_READYb */
+	ret = ad4692_reg_update(desc,
+				AD4692_GPIO_MODE1_REG,
+				AD4692_GPIO0_MASK,
+				AD4692_GPIO_OUTPUT_DATA_READYb);
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure DATA_READYb as the stop state trigger */
+	ret = ad4692_reg_update(desc,
+				AD4692_ADC_SETUP_REG,
+				AD4692_ADC_MODE_STOP_STATE_MASK,
+				no_os_field_prep(AD4692_ADC_MODE_STOP_STATE_MASK,
+						AD4692_STOP_STATE_DATA_READYb));
+	if (ret) {
+		return ret;
+	}
+
+	/* Configure the oscillator frequency */
+	ret = ad4692_set_osc(desc, ad4692_osc_freq_id);
+	if (ret) {
+		return ret;
+	}
+
+	/* Enter SPI Burst Mode */
+	ret = ad4692_reg_update(desc,
+				AD4692_ADC_SETUP_REG,
+				AD4692_MODE_MASK,
+				AD4692_SPI_BURST);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Prepare for ADC data transfer in SPI burst mode
+ * @param dev[in] - IIO device instance
+ * @param ch_mask[in] - Channels select mask
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_spi_burst_prepare_transfer(void *dev,
+		uint32_t ch_mask)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	ad4692_update_active_channels(ch_mask);
+
+	ret = ad4692_configure_channel(ad4692_dev);
+	if (ret) {
+		return ret;
+	}
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ret = iio_trig_enable(ad4692_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+
+		ret = ad4692_config_and_start_pwm(ad4692_dev);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Submit samples in SPI burst mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_spi_burst_submit_samples(
+	struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+	uint32_t sample_index = 0;
+	uint32_t nb_of_samples;
+	ad4692_conversion_flag = false;
+	uint8_t i = 0;
+	uint32_t data_read_local;
+	uint8_t eoc_status;
+	uint8_t offset = 0;
+
+	if (!iio_dev_data) {
+		return -EINVAL;
+	}
+
+	nb_of_samples = iio_dev_data->buffer->size / n_data_bytes;
+
+	if (!buf_size_updated) {
+		iio_dev_data->buffer->buf->size = iio_dev_data->buffer->size;
+		buf_size_updated = true;
+	}
+
+#if (ACTIVE_PLATFORM == STM32_PLATFORM)
+	ret = no_os_irq_clear_pending(trigger_irq_desc,
+				      trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+#endif
+
+	ret = no_os_irq_enable(trigger_irq_desc,
+			       trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	/* Config CNV PWM and start */
+	ret = ad4692_config_and_start_pwm(ad4692_dev);
+	if (ret) {
+		goto disable_timer;
+	}
+
+	while (sample_index < nb_of_samples) {
+		/* Build the Tx Command */
+		ad4692_get_tx_command(acc_data_buff);
+
+		/* Write to Convert Start register to trigger the next burst */
+		ret = ad4692_reg_write(ad4692_dev,
+				       AD4692_OSC_EN_REG,
+				       AD4692_CONV_START_MASK);
+		if (ret) {
+			goto disable_timer;
+		}
+
+		/* Check for status of conversion flag */
+		while (!ad4692_conversion_flag && timeout > 0) {
+			timeout--;
+		}
+
+		if (timeout == 0) {
+			ret = -ETIMEDOUT;
+			goto disable_timer;
+		}
+		timeout = BUF_READ_TIMEOUT;
+
+		ad4692_conversion_flag = false;
+
+		/* Poll for BSY Low */
+		do {
+			ret = no_os_gpio_get_value(ad4692_dev->gpio0_desc, &eoc_status);
+			if (ret) {
+				goto disable_timer;
+			}
+		} while ((eoc_status != NO_OS_GPIO_LOW) && (--timeout > 0));
+
+		if (timeout == 0) {
+			ret = -ETIMEDOUT;
+			goto disable_timer;
+		}
+		timeout = BUF_READ_TIMEOUT;
+
+		ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
+					       num_of_active_channels * n_bytes_per_transaction);
+		if (ret) {
+			goto disable_timer;
+		}
+
+		for (i = 0; i < num_of_active_channels; i++) {
+			offset = (i * n_bytes_per_transaction) + AD4692_N_BYTES_TXN_OFFSET;
+			if (ad4692_readback_option == ACCUMULATOR_DATA) {
+				data_read_local = no_os_get_unaligned_be24(&acc_data_buff[offset]);
+			} else {
+				data_read_local = no_os_get_unaligned_be16(&acc_data_buff[offset]);
+			}
+
+			ret = no_os_cb_write(iio_dev_data->buffer->buf,
+					     &data_read_local,
+					     n_data_bytes);
+			if (ret) {
+				goto disable_timer;
+			}
+		}
+
+		/* Reset the state of accumulator */
+		ret = ad4692_reg_write(ad4692_dev,
+				       AD4692_STATE_RESET_REG,
+				       AD4692_STATE_RESET_ALL);
+		if (ret) {
+			goto disable_timer;
+		}
+
+		sample_index += num_of_active_channels;
+	}
+
+disable_timer:
+	/* Stop timer */
+	ad4692_stop_timer();
+
+	/* Disable triggers */
+	ret |= no_os_irq_disable(trigger_irq_desc,
+				 trigger_gpio_irq_params.irq_ctrl_id);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Trigger handler for SPI burst mode
+ * @param iio_dev_data[in] - IIO device data instance
+ * @return 0 in case of success or negative value otherwise
+ */
+static int32_t ad4692_spi_burst_trigger_handler(
+	struct iio_device_data *iio_dev_data)
+{
+	int32_t ret;
+	uint32_t data_read_local = 0;
+	uint8_t eoc_status;
+	uint8_t offset = 0;
+	uint8_t i = 0;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+
+	/* Populate the Tx command */
+	ad4692_get_tx_command(acc_data_buff);
+
+	/* Write to Convert Start register to trigger the next burst */
+	ret = ad4692_reg_write(ad4692_dev,
+			       AD4692_OSC_EN_REG,
+			       AD4692_CONV_START_MASK);
+	if (ret) {
+		return ret;
+	}
+
+	/* Poll for BSY Low */
+	do {
+		ret = no_os_gpio_get_value(ad4692_dev->gpio0_desc, &eoc_status);
+		if (ret) {
+			return ret;
+		}
+	} while ((eoc_status != NO_OS_GPIO_LOW) && (--timeout > 0));
+
+	if (timeout == 0) {
+		return -ETIMEDOUT;
+	}
+
+	ret = no_os_spi_write_and_read(ad4692_dev->comm_desc, acc_data_buff,
+				       num_of_active_channels * n_bytes_per_transaction);
+	if (ret) {
+		return ret;
+	}
+
+	for (i = 0; i < num_of_active_channels; i++) {
+		offset = (i * n_bytes_per_transaction) + AD4692_N_BYTES_TXN_OFFSET;
+		if (ad4692_readback_option == ACCUMULATOR_DATA) {
+			data_read_local = no_os_get_unaligned_be24(&acc_data_buff[offset]);
+		} else {
+			data_read_local = no_os_get_unaligned_be16(&acc_data_buff[offset]);
+		}
+
+		ret = no_os_cb_write(iio_dev_data->buffer->buf,
+				     &data_read_local,
+				     n_data_bytes);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* Reset the state of accumulator */
+	ret = ad4692_reg_write(ad4692_dev,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief End data transfer in SPI burst mode
+ * @param dev[in] - IIO device instance
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_spi_burst_end_transfer(void *dev)
+{
+	int32_t ret;
+
+	if (!dev) {
+		return -EINVAL;
+	}
+
+	if (ad4692_data_capture_mode == CONTINUOUS_DATA_CAPTURE) {
+		ad4692_stop_timer();
+
+		ret = iio_trig_disable(ad4692_hw_trig_desc);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	buf_size_updated = false;
+
+	return 0;
+}
+
+/**
+ * @brief Read single-shot ADC data in SPI burst mode
+ * @param desc[in] - AD4692 device descriptor
+ * @param chn[in] - Channel number
+ * @param adc_data[out] - ADC converted data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_spi_burst_read_converted_data(struct ad4692_desc *desc,
+		uint8_t chn, uint32_t *adc_data)
+{
+	int32_t ret;
+	uint8_t eoc_status;
+	uint32_t timeout = BUF_READ_TIMEOUT;
+
+	ret = ad4692_configure_channel(desc);
+	if (ret) {
+		return ret;
+	}
+
+	/* Write to Convert Start register to trigger the burst of conversion */
+	ret = ad4692_reg_write(desc,
+			       AD4692_OSC_EN_REG,
+			       AD4692_CONV_START_MASK);
+	if (ret) {
+		return ret;
+	}
+
+	eoc_status = NO_OS_GPIO_HIGH;
+
+	/* Poll for DATA_READYb Low */
+	do {
+		ret = no_os_gpio_get_value(desc->gpio0_desc, &eoc_status);
+		if (ret) {
+			return ret;
+		}
+	} while (eoc_status != NO_OS_GPIO_LOW && --timeout > 0);
+
+	if (timeout == 0) {
+		return -ETIMEDOUT;
+	}
+
+	ret = ad4692_reg_read(desc,
+			      AD4692_AVG_IN_REG(chn),
+			      adc_data);
+	if (ret) {
+		return ret;
+	}
+	*adc_data = no_os_get_unaligned_be16((uint8_t *)adc_data);
+
+	/* Reset the state of accumulator */
+	ret = ad4692_reg_write(desc,
+			       AD4692_STATE_RESET_REG,
+			       AD4692_STATE_RESET_ALL);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Update sampling frequency for SPI burst mode
+ * @param sampling_rate[in,out] - Requested/actual sampling rate
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad4692_spi_burst_update_sampling_frequency(
+	uint32_t *sampling_rate)
+{
+	int32_t ret;
+	uint32_t period_ns_readback;
+
+	if (*sampling_rate > ad4692_sampling_frequency_max) {
+		*sampling_rate = ad4692_sampling_frequency_max;
+	}
+
+	ret = ad4692_configure_pwm_rate(spi_burst_pwm_desc, *sampling_rate);
+	if (ret) {
+		return ret;
+	}
+
+	/* Get the actual period of the PWM */
+	ret = no_os_pwm_get_period(spi_burst_pwm_desc, &period_ns_readback);
+	if (ret) {
+		return ret;
+	}
+
+	ad4692_sampling_frequency = PWM_PERIOD_TO_FREQUENCY(period_ns_readback);
+
+	return 0;
+}
+
+/**
+ * @brief Get maximum sampling rate for SPI burst mode
+ * @return Maximum sampling rate in samples per second
+ */
+static uint32_t ad4692_spi_burst_get_max_sampling_rate(void)
+{
+	if (ad4692_sequencer_mode == STANDARD_SEQUENCER) {
+		return (ad4692_readback_option == AVERAGED_DATA) ?
+		       S_RATE_SPI_BURST_STD_AVG : S_RATE_SPI_BURST_STD_ACC;
+	}
+
+	return (ad4692_readback_option == AVERAGED_DATA) ?
+	       S_RATE_SPI_BURST_ADV_AVG : S_RATE_SPI_BURST_ADV_ACC;
+}
+
+/* SPI burst mode data transfer system instance */
+struct ad4692_data_transfer_system ad4692_data_transfer_spi_burst_mode = {
+	.initialize = ad4692_spi_burst_init,
+	.prepare_transfer = ad4692_spi_burst_prepare_transfer,
+	.submit_samples = ad4692_spi_burst_submit_samples,
+	.trigger_handler = ad4692_spi_burst_trigger_handler,
+	.end_transfer = ad4692_spi_burst_end_transfer,
+	.remove = NULL,
+	.read_converted_data = ad4692_spi_burst_read_converted_data,
+	.update_sampling_frequency = ad4692_spi_burst_update_sampling_frequency,
+	.get_max_sampling_rate = ad4692_spi_burst_get_max_sampling_rate,
+};

--- a/projects/ad4692_iio/app/ad4692_support_spi_burst_mode.c
+++ b/projects/ad4692_iio/app/ad4692_support_spi_burst_mode.c
@@ -3,7 +3,7 @@
  *   @brief   AD4692 SPI Burst Mode data transfer implementation
  *   @details Contains all data capture logic specific to SPI Burst Mode
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * By using this software you agree to the terms of the associated

--- a/projects/ad4692_iio/app/ad4692_user_config.c
+++ b/projects/ad4692_iio/app/ad4692_user_config.c
@@ -2,7 +2,7 @@
  *   @file   ad4692_user_config.c
  *   @brief  User configuration file for AD4692 device
 ******************************************************************************
-* Copyright (c) 2024 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad4692_iio/app/ad4692_user_config.c
+++ b/projects/ad4692_iio/app/ad4692_user_config.c
@@ -38,14 +38,6 @@ struct no_os_spi_init_param ad4692_spi_init = {
 	.extra = &spi_extra_init_params,
 };
 
-/* PWM GPIO init parameters */
-struct no_os_gpio_init_param cnv_pwm_gpio_params = {
-	.port = CNV_PORT_NUM,
-	.number = CNV_PIN_NUM,
-	.platform_ops = &gpio_ops,
-	.extra = &cnv_pwm_gpio_extra_init_params
-};
-
 /* PWM init parameters for conversion pulses */
 struct no_os_pwm_init_param pwm_init_convst = {
 	.id = CNV_TIMER_ID,

--- a/projects/ad4692_iio/app/ad4692_user_config.h
+++ b/projects/ad4692_iio/app/ad4692_user_config.h
@@ -2,7 +2,7 @@
  *   @file   ad4692_user_config.h
  *   @brief  Header for AD4692 user configuration file
 ******************************************************************************
-* Copyright (c) 2024 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad4692_iio/app/app_config.c
+++ b/projects/ad4692_iio/app/app_config.c
@@ -78,19 +78,19 @@ struct no_os_uart_init_param uart_console_stdio_init_params = {
 };
 #endif
 
+/* PWM GPIO init parameters */
+struct no_os_gpio_init_param cnv_pwm_gpio_params = {
+	.port = CNV_PORT_NUM,
+	.number = CNV_PIN_NUM,
+	.platform_ops = &gpio_ops,
+	.extra = &cnv_pwm_gpio_extra_init_params
+};
+
 /* External interrupt init parameters */
 struct no_os_irq_init_param trigger_gpio_irq_params = {
 	.irq_ctrl_id = TRIGGER_INT_ID,
 	.platform_ops = &trigger_gpio_irq_ops,
 	.extra = &trigger_gpio_irq_extra_params
-};
-
-/* CNV GPIO Init params */
-struct no_os_gpio_init_param cnv_gpio_init_param = {
-	.port = CNV_PORT_NUM,
-	.number = CNV_PIN_NUM,
-	.platform_ops = &gpio_ops,
-	.extra = &gpio_input_extra_init_params
 };
 
 /* External interrupt callback descriptor */
@@ -146,8 +146,6 @@ struct no_os_uart_desc *uart_iio_com_desc;
 /* Console Descriptor */
 struct no_os_uart_desc *uart_console_stdio_desc;
 
-/* CNV GPIO descriptor */
-struct no_os_gpio_desc *cnv_gpio_desc = NULL;
 
 /* EEPROM descriptor */
 struct no_os_eeprom_desc* eeprom_desc;
@@ -160,33 +158,8 @@ struct no_os_dma_init_param ad4692_dma_init_param = {
 	.sg_handler = (void (*)(void *))ad4692_spi_dma_rx_cplt_callback,
 };
 
-/* Tx Trigger Init params */
-struct no_os_pwm_init_param tx_trigger_init_param = {
-	.id = TX_TRIGGER_TIMER_ID,
-	.period_ns = TX_TRIGGER_PERIOD,
-	.duty_cycle_ns = TX_TRIGGER_DUTY_RATIO,
-	.polarity = NO_OS_PWM_POLARITY_HIGH,
-	.platform_ops = &pwm_ops,
-	.extra = &tx_trigger_extra_init_params,
-};
-
-/* Chip Select GPIO init parameters */
-struct no_os_gpio_init_param csb_gpio_init_param = {
-	.port = SPI_CS_PORT_NUM,
-	.number = SPI_CSB,
-	.pull = NO_OS_PULL_NONE,
-	.platform_ops = &gpio_ops,
-	.extra = &gpio_output_extra_init_params
-};
-
-/* Tx trigger descriptor */
-struct no_os_pwm_desc *tx_trigger_desc;
-
 /* SPI Burst PWM Descriptor */
 struct no_os_pwm_desc *spi_burst_pwm_desc = NULL;
-
-/* Chip Select GPIO descriptor */
-struct no_os_gpio_desc* csb_gpio_desc = NULL;
 
 /******************************************************************************/
 /************************ Functions Prototypes ********************************/
@@ -222,58 +195,6 @@ static int32_t init_uart(void)
 #endif
 
 	return 0;
-}
-
-/**
- * @brief Remove the initialized GPIO peripheral.
- * @return None.
- */
-void remove_gpio(void)
-{
-	NO_OS_UNUSED_PARAM(no_os_gpio_remove(csb_gpio_desc));
-	csb_gpio_desc = NULL;
-	NO_OS_UNUSED_PARAM(no_os_gpio_remove(cnv_gpio_desc));
-	cnv_gpio_desc = NULL;
-	return;
-}
-
-/**
- * @brief Initialize the GPIO peripheral.
- * @return 0 in case of success, negative error code otherwise.
- */
-int init_gpio(void)
-{
-	int ret;
-
-	/* Remove Exiting GPIO descriptors */
-	remove_gpio();
-
-	ret = no_os_gpio_get(&cnv_gpio_desc, &cnv_gpio_init_param);
-	if (ret) {
-		return ret;
-	}
-
-	ret = no_os_gpio_direction_output(cnv_gpio_desc, NO_OS_GPIO_LOW);
-	if (ret) {
-		goto err_init_gpio;
-	}
-
-	if (ad4692_interface_mode == SPI_DMA) {
-		ret = no_os_gpio_get(&csb_gpio_desc, &csb_gpio_init_param);
-		if (ret) {
-			goto err_init_gpio;
-		}
-
-		ret = no_os_gpio_direction_output(csb_gpio_desc, NO_OS_GPIO_LOW);
-		if (ret) {
-			goto err_init_gpio;
-		}
-	}
-
-	return 0;
-err_init_gpio:
-	remove_gpio();
-	return ret;
 }
 
 /**
@@ -319,7 +240,7 @@ int32_t init_interrupt(void)
 			return ret;
 		}
 
-		if (ad4692_data_capture_mode == BURST) {
+		if (ad4692_data_capture_mode == BURST_DATA_CAPTURE) {
 			/* The BSY pin has been tied as the interrupt source to sense the
 			 * End of Conversion. The registered callback function is responsible
 			 * of reading the raw samples via the SPI bus */
@@ -373,12 +294,9 @@ void remove_pwm(void)
  * @brief Initialize CNV PWM
  * @return 0 in case of success, negative error code otherwise.
  */
-int init_pwm(void)
+int32_t init_pwm(void)
 {
-	int ret;
-
-	/* Remove Existing PWM descriptors */
-	remove_pwm();
+	int32_t ret;
 
 	if (ad4692_init_params.mode == AD4692_SPI_BURST) {
 		/* Initialize timer for SPI Burst PWM */
@@ -404,38 +322,11 @@ int init_pwm(void)
 		goto err_init_pwm;
 	}
 
-	/* Stop timer */
-	ad4692_stop_timer();
-
 	return 0;
 
 err_init_pwm:
 	remove_pwm();
 	return ret;
-}
-
-/**
- * @brief 	Initialize Tx Trigger Timer
- * @return	0 in case of success, negative error code otherwise
- */
-int32_t tx_trigger_init(void)
-{
-	int ret;
-
-	if (ad4692_interface_mode == SPI_DMA) {
-		/* Free previous tx_trigger_desc before reinit */
-		if (tx_trigger_desc) {
-			no_os_pwm_remove(tx_trigger_desc);
-			tx_trigger_desc = NULL;
-		}
-
-		ret = no_os_pwm_init(&tx_trigger_desc, &tx_trigger_init_param);
-		if (ret) {
-			return ret;
-		}
-	}
-
-	return 0;
 }
 
 /**
@@ -466,7 +357,7 @@ int32_t set_timer_prescaler(struct no_os_pwm_desc *desc, uint32_t prescaler)
  */
 int32_t init_system(void)
 {
-	int ret;
+	int32_t ret;
 
 #if (ACTIVE_PLATFORM == STM32_PLATFORM)
 	stm32_system_init();

--- a/projects/ad4692_iio/app/app_config.c
+++ b/projects/ad4692_iio/app/app_config.c
@@ -3,7 +3,7 @@
  *   @brief   Application configurations module
  *   @details This module contains the configurations needed for IIO application
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  * All rights reserved.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.

--- a/projects/ad4692_iio/app/app_config.h
+++ b/projects/ad4692_iio/app/app_config.h
@@ -130,18 +130,15 @@
 extern struct no_os_uart_desc *uart_iio_com_desc;
 extern struct no_os_uart_desc *uart_console_stdio_desc;
 extern struct no_os_irq_ctrl_desc *trigger_irq_desc;
-extern struct no_os_gpio_desc *cnv_gpio_desc;
 extern struct no_os_eeprom_desc* eeprom_desc;
-extern struct no_os_pwm_desc *tx_trigger_desc;
 extern struct no_os_pwm_desc *spi_burst_pwm_desc;
+extern struct no_os_gpio_init_param cnv_pwm_gpio_params;
 extern struct no_os_pwm_init_param pwm_spi_burst_init;
 extern struct no_os_irq_init_param trigger_gpio_irq_params;
 
 int32_t init_system(void);
 int32_t set_timer_prescaler(struct no_os_pwm_desc *desc, uint32_t prescaler);
-int init_gpio(void);
-void remove_gpio(void);
-int init_pwm(void);
+int32_t init_pwm(void);
 void remove_pwm(void);
 void ad4692_data_capture_callback(void *ctx);
 int32_t init_interrupt(void);

--- a/projects/ad4692_iio/app/app_config.h
+++ b/projects/ad4692_iio/app/app_config.h
@@ -2,7 +2,7 @@
  *   @file   app_config.h
  *   @brief  Configuration file for AD4692 device applications
 ******************************************************************************
-* Copyright (c) 2024, 2026 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad4692_iio/app/app_config_stm32.c
+++ b/projects/ad4692_iio/app/app_config_stm32.c
@@ -183,6 +183,7 @@ struct stm32_spi_desc* sdesc;
 void stm32_system_init(void)
 {
 	HAL_Init();
+	HAL_Delay(2000);
 	SystemClock_Config();
 
 	MX_GPIO_Init();

--- a/projects/ad4692_iio/app/app_config_stm32.c
+++ b/projects/ad4692_iio/app/app_config_stm32.c
@@ -2,7 +2,7 @@
  * @file    app_config_stm32.c
  * @brief   Source file for STM32 platform configurations
 ********************************************************************************
-* Copyright (c) 2024 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 * All rights reserved.
 *
 * This software is proprietary to Analog Devices, Inc. and its licensors.

--- a/projects/ad4692_iio/app/app_config_stm32.c
+++ b/projects/ad4692_iio/app/app_config_stm32.c
@@ -192,10 +192,6 @@ void stm32_system_init(void)
 	MX_SPI1_Init();
 	MX_DMA_Init();
 
-	MX_TIM1_Init();
-	MX_TIM4_Init();
-	MX_TIM8_Init();
-
 #ifdef USE_VIRTUAL_COM_PORT
 	MX_USB_DEVICE_Init();
 #endif
@@ -205,16 +201,18 @@ void stm32_system_init(void)
  * @param desc[in] - Device descriptor
  * @return 0 in case of success, negative error code otherwise.
  */
-int ad4692_config_and_start_pwm(struct ad4692_desc *desc)
+int32_t ad4692_config_and_start_pwm(struct ad4692_desc *desc)
 {
-	int ret;
+	int32_t ret;
 
 	if (!desc) {
 		return -EINVAL;
 	}
 
 	/* Enable Tx Trigger DMA */
-	TIM8->DIER |= TIM_DIER_CC1DE;
+	if (ad4692_interface_mode == SPI_DMA) {
+		TIM8->DIER |= TIM_DIER_CC1DE;
+	}
 
 	/* Enable CNV PWM for any mode other than SPI Burst */
 	if (ad4692_init_params.mode != AD4692_SPI_BURST) {
@@ -309,7 +307,9 @@ void ad4692_spi_dma_rx_half_cplt_callback(DMA_HandleTypeDef* hdma)
  */
 void ad4692_spi_dma_rx_cplt_callback(DMA_HandleTypeDef* hdma)
 {
-	if (ad4692_data_capture_mode == BURST) {
+	uint32_t data_read;
+
+	if (ad4692_data_capture_mode == BURST_DATA_CAPTURE) {
 		/* Update samples captured so far */
 		dma_cycle_count -= 1;
 
@@ -344,13 +344,13 @@ void ad4692_spi_dma_rx_cplt_callback(DMA_HandleTypeDef* hdma)
  */
 void DMA2_Stream0_IRQHandler(void)
 {
-	if (ad4692_data_capture_mode == BURST) {
+	if (ad4692_data_capture_mode == BURST_DATA_CAPTURE) {
 		/* Stop Tx trigger DMA and CNV timer at the last entry
 		to the callback */
 		if (callback_count == 1) {
 			TIM8->DIER &= ~TIM_DIER_CC1DE;
 		}
-	} else { // CONTINUOUS
+	} else { // CONTINUOUS_DATA_CAPTURE
 		memcpy(iio_buf_current_idx,
 		       dma_buf_current_idx, rxdma_ndtr);
 	}

--- a/projects/ad4692_iio/app/app_config_stm32.h
+++ b/projects/ad4692_iio/app/app_config_stm32.h
@@ -2,7 +2,7 @@
  *   @file    app_config_stm32.h
  *   @brief   Header file for STM32 platform configurations
 ********************************************************************************
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  * All rights reserved.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.

--- a/projects/ad4692_iio/app/app_config_stm32.h
+++ b/projects/ad4692_iio/app/app_config_stm32.h
@@ -183,11 +183,9 @@ extern uint8_t num_of_active_channels;
 extern volatile struct iio_device_data* iio_dev_data_g;
 extern uint32_t nb_of_samples_g;
 extern volatile uint32_t* buff_start_addr;
-extern uint32_t data_read;
 extern uint32_t rxdma_ndtr;
 extern volatile bool ad4692_dma_buff_full;
 extern uint32_t dma_cycle_count;
-extern struct no_os_gpio_desc* csb_gpio_desc;
 extern uint32_t callback_count;
 extern USBD_HandleTypeDef hUsbDeviceHS;
 extern struct stm32_usb_uart_init_param stm32_vcom_extra_init_params;
@@ -195,14 +193,13 @@ void MX_USB_DEVICE_Init(void);
 extern UART_HandleTypeDef huart5;
 
 void stm32_system_init(void);
-int ad4692_config_and_start_pwm(struct ad4692_desc *desc);
+int32_t ad4692_config_and_start_pwm(struct ad4692_desc *desc);
 void ad4692_stop_timer(void);
 void ad4692_spi_dma_rx_cplt_callback(DMA_HandleTypeDef* hdma);
 void ad4692_spi_dma_rx_half_cplt_callback(DMA_HandleTypeDef* hdma);
 void stm32_abort_dma_transfer(void);
 void update_buff(uint8_t *local_buf, uint8_t *buf_start_addr);
 void SystemClock_Config(void);
-int32_t tx_trigger_init(void);
 void stm32_tim4_init(void);
 
 #endif /* APP_CONFIG_STM32_H_ */

--- a/projects/ad4692_iio/app/main.c
+++ b/projects/ad4692_iio/app/main.c
@@ -2,7 +2,7 @@
  *   @file    main.c
  *   @brief   Main interface for IIO firmware application
 ********************************************************************************
- * Copyright (c) 2024, 2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * By using this software you agree to the terms of the associated

--- a/projects/ad4692_iio/app/stm32_gpio_irq_generated.c
+++ b/projects/ad4692_iio/app/stm32_gpio_irq_generated.c
@@ -2,7 +2,7 @@
  * @file    stm32_gpio_irq_generated.c
  * @brief   GPIO IRQ specific functions for STM32 platform
 ********************************************************************************
-* Copyright (c) 2024 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 * All rights reserved.
 *
 * This software is proprietary to Analog Devices, Inc. and its licensors.

--- a/projects/ad4692_iio/app/version.h
+++ b/projects/ad4692_iio/app/version.h
@@ -2,7 +2,7 @@
  *   @file   version.h
  *   @brief  Version macros for AD4692 IIO Firmware
 ******************************************************************************
-* Copyright (c) 2025-26 Analog Devices, Inc.
+* Copyright (c) 2026 Analog Devices, Inc.
 *
 * All rights reserved.
 *

--- a/projects/ad4692_iio/app/version.h
+++ b/projects/ad4692_iio/app/version.h
@@ -18,9 +18,9 @@
 
 /******************************************************************************/
 /* Define firmware_version string */
-#define MAJOR_VERSION		1
+#define MAJOR_VERSION		2
 #define MINOR_VERSION		0
-#define PATCH_VERSION		1
+#define PATCH_VERSION		0
 #define QUALITY_LEVEL 		QUALITY_LEVEL_RC
 #define STATE_VERSION		0
 


### PR DESCRIPTION
1. Fix the IIO buffer address and size for adc_data_buffer to accomodate the extra cycles required for data capture.
2. Added delay in STM32 initialization to accomodate the delay observed in 3.3V line when powered using USB cables.
3. Split the data capture into 4 files based on the modes.
4. Move the individual init params and descriptors into the mode support files if used only in a single mode.
5. Remove unnecessary init and remove functions from app_cofig.
6. Move global variables to local wherever possible.
7. Optimize Support function
8. Fix Copyright year
9. Updated Version to 2.0.0